### PR TITLE
ODYA-29 OpenSearch연동

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,13 @@ dependencies {
     implementation("com.oracle.oci.sdk:oci-java-sdk-objectstorage:3.14.0")
     implementation("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey3:3.14.0")
 
+    implementation("org.opensearch.client:spring-data-opensearch-starter:1.1.0") {
+        exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
+    }
+    implementation("org.opensearch.client:spring-data-opensearch-test-autoconfigure:1.1.0") {
+        exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
+    }
+
     asciidoctorExt("org.springframework.restdocs:spring-restdocs-asciidoctor")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
 }

--- a/src/main/kotlin/kr/weit/odya/OdyaApplication.kt
+++ b/src/main/kotlin/kr/weit/odya/OdyaApplication.kt
@@ -1,11 +1,12 @@
 package kr.weit.odya
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 @ConfigurationPropertiesScan
-@SpringBootApplication
+@SpringBootApplication(exclude = [ElasticsearchDataAutoConfiguration::class])
 class OdyaApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/kr/weit/odya/config/OpenSearchConfig.kt
+++ b/src/main/kotlin/kr/weit/odya/config/OpenSearchConfig.kt
@@ -1,0 +1,41 @@
+package kr.weit.odya.config
+
+import kr.weit.odya.config.properties.OpenSearchProperties
+import org.apache.http.HttpHost
+import org.apache.http.auth.AuthScope
+import org.apache.http.auth.UsernamePasswordCredentials
+import org.apache.http.client.CredentialsProvider
+import org.apache.http.impl.client.BasicCredentialsProvider
+import org.opensearch.client.RestClient
+import org.opensearch.client.RestClientBuilder
+import org.opensearch.client.RestHighLevelClient
+import org.opensearch.data.client.orhlc.AbstractOpenSearchConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories
+
+@Profile("!test")
+@Configuration(proxyBeanMethods = false)
+@EnableElasticsearchRepositories
+class OpenSearchConfig(private val properties: OpenSearchProperties) : AbstractOpenSearchConfiguration() {
+    @Bean
+    override fun opensearchClient(): RestHighLevelClient {
+        val credentialsProvider: CredentialsProvider = BasicCredentialsProvider()
+
+        credentialsProvider.setCredentials(
+            AuthScope.ANY,
+            UsernamePasswordCredentials(properties.username, properties.password)
+        )
+        val builder: RestClientBuilder = RestClient.builder(
+            HttpHost(
+                properties.serverUrl,
+                443,
+                "https"
+            )
+        ).setHttpClientConfigCallback { httpClientBuilder ->
+            httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
+        }
+        return RestHighLevelClient(builder)
+    }
+}

--- a/src/main/kotlin/kr/weit/odya/config/properties/OpenSearchProperties.kt
+++ b/src/main/kotlin/kr/weit/odya/config/properties/OpenSearchProperties.kt
@@ -1,0 +1,10 @@
+package kr.weit.odya.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("open-search")
+data class OpenSearchProperties(
+    val serverUrl: String,
+    val username: String,
+    val password: String
+)

--- a/src/main/resources/application-open-search.yml
+++ b/src/main/resources/application-open-search.yml
@@ -1,0 +1,4 @@
+open-search:
+  server-url: ${OPEN_SEARCH_URL}
+  user-name: ${OPEN_SEARCH_USER_NAME}
+  password: ${OPEN_SEARCH_PASSWORD}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,4 @@ spring:
       - object-storage
       - sentry
       - flyway
+      - open-search


### PR DESCRIPTION
### 개요
- 추후 많은 데이터 검색에 사용될 ES(OpenSearch)연동을 했습니다

### 변경사항
- 관련 라이브러리 추가
- 설정 추가

### 관련 지라 및 위키 링크
- [ODYA-29](https://weit.atlassian.net/browse/ODYA-29)

### 리뷰어에게 하고 싶은 말
- 요거 ES 사용방법도 작업에 추가할까 하다가 어차피 임시코드일것 같아서 샌박에만 코드 넣어놨습니다
- 나중에 작업하실때 샌박에 사용코드 참고 부탁드립니다~!
