### PR TITLE
ODYA-35 Spring cloud config 도입

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM ghcr.io/weit-1st/odya-gradle-cache AS build
 COPY . /app
 WORKDIR /app
 
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
+
 RUN ./gradlew assemble
 
 FROM eclipse-temurin:17.0.7_7-jdk AS run

--- a/Dockerfile-cache
+++ b/Dockerfile-cache
@@ -3,5 +3,8 @@ FROM eclipse-temurin:17.0.7_7-jdk AS cache
 COPY . /app
 WORKDIR /app
 
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
+
 RUN ./gradlew assemble && \
     rm -rf /app

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,10 @@ dependencies {
         exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
     }
 
+    implementation(platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.1"))
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-parameter-store")
+    implementation("org.springframework.cloud:spring-cloud-starter-bootstrap:4.0.3")
+
     asciidoctorExt("org.springframework.restdocs:spring-restdocs-asciidoctor")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")

--- a/src/main/kotlin/kr/weit/odya/config/properties/OpenSearchProperties.kt
+++ b/src/main/kotlin/kr/weit/odya/config/properties/OpenSearchProperties.kt
@@ -1,7 +1,9 @@
 package kr.weit.odya.config.properties
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Profile
 
+@Profile("!test")
 @ConfigurationProperties("open-search")
 data class OpenSearchProperties(
     val serverUrl: String,

--- a/src/main/resources/application-database.yml
+++ b/src/main/resources/application-database.yml
@@ -9,9 +9,6 @@ spring:
   config.activate.on-profile: sandbox, stable
   datasource:
     driver-class-name: oracle.jdbc.OracleDriver
-    url: ${DATASOURCE_URL}
-    username: ${DB_USER_NAME}
-    password: ${DB_PASSWORD}
     hikari:
       maximum-pool-size: 8 # DB 최대 세션수가 30개인데 서버배포시 rolling update를 할때 디폴트 값인 10개씩 먹으면 아슬아슬해서 줄였습니다!
   jpa:

--- a/src/main/resources/application-object-storage.yml
+++ b/src/main/resources/application-object-storage.yml
@@ -1,15 +1,2 @@
 object:
   configuration-file-path: ${OBJECT_STORAGE_CONFIG_FILE_PATH}
-  namespace-name: "axivk99fjind"
-
----
-spring.config.activate.on-profile: sandbox
-
-object:
-  bucket-name: "Odya-sandbox"
-
----
-spring.config.activate.on-profile: stable
-
-object:
-  bucket-name: "Odya-stable"

--- a/src/main/resources/application-open-search.yml
+++ b/src/main/resources/application-open-search.yml
@@ -1,4 +1,0 @@
-open-search:
-  server-url: ${OPEN_SEARCH_URL}
-  user-name: ${OPEN_SEARCH_USER_NAME}
-  password: ${OPEN_SEARCH_PASSWORD}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,17 +2,17 @@ spring:
   application:
     name: Odya
   profiles:
-    active: sandbox
     include:
       - database
       - object-storage
       - sentry
       - flyway
-      - open-search
   servlet:
     multipart:
       max-file-size: 50MB # 사진 1개당 약 100kb * 최대 15일까지 한번에 올릴수 있음 * 1일당 30장까지 올릴수 있음 + 10% 버퍼 = 50MB
-
+  cloud:
+    compatibility-verifier:
+      enabled: false
 server:
   error:
     whitelabel:

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -2,7 +2,7 @@ spring:
   profiles:
     active: sandbox
   config:
-    import: 'aws-parameterstore:/config/Odya_${spring.profiles.active}'
+    import: 'optional:aws-parameterstore:/config/Odya_${spring.profiles.active}'
   cloud:
     aws:
       region:

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,0 +1,9 @@
+spring:
+  profiles:
+    active: sandbox
+  config:
+    import: 'aws-parameterstore:/config/Odya_${spring.profiles.active}'
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2


### PR DESCRIPTION
### 개요
- 인프라 접속을 위한 비밀정보들을 공유하고 사용하기에 껄끄러웠다

### 변경사항
- Spring cloud config를 이용한 자동 프로퍼티 주입을 추가 했다
- AWS의 Parameter store라는 기능을 사용했다
- 하지만 사람마다 다른 파일 위치는 그대로 환경변수를 통해 주입하도록 한다

### 관련 지라 및 위키 링크
- [ODYA-35](https://weit.atlassian.net/browse/ODYA-35)

### 리뷰어에게 하고 싶은 말
- 대부분의 프로퍼티를 걷어 냈지만 AWS의 Parameter store를 접속하기 위한 프로퍼티가 2개 추가 되었고 
- 요 PR머지되면 그때 공유드리겠습니다~!