### PR TITLE
ODYA-82 완료 상태 이름 수정

### DIFF
--- a/.github/workflows/issueTransition.yml
+++ b/.github/workflows/issueTransition.yml
@@ -35,4 +35,4 @@ jobs:
         uses: atlassian/gajira-transition@master
         with:
           issue: ${{ steps.jira-ticket.outputs.issue }}
-          transition: "Done"
+          transition: "완료"


### PR DESCRIPTION
### 개요
- 완료 상태가 잘못 정의가 되어있었다

### 변경사항
- 제대로된 "완료"상태 적용

### 관련 지라 및 위키 링크
- https://github.com/weIT-1st/Odya-android/pull/22

### 리뷰어에게 하고 싶은 말
- 이 PR도 제대로 안된다면 민성님을 혼내도록 하겠습니다
