### PR TITLE
ODYA-118 사용자 닉네임 검색 작업

### DIFF
--- a/src/docs/asciidoc/follow.adoc
+++ b/src/docs/asciidoc/follow.adoc
@@ -87,3 +87,30 @@ operation::follow-controller-test/get-follower-slice-fail-invalid-user-id[snippe
 === *5-4 실패 - 유효하지 않은 토큰인 경우*
 
 operation::follow-controller-test/get-follower-slice-fail-invalid-token[snippets='http-request,request-headers,path-parameters,http-response']
+
+[[팔로잉-검색-API]]
+== *6. 팔로잉 검색 API*
+
+=== *6-1 성공*
+
+operation::follow-controller-test/search-followings-success[snippets='http-request,request-headers,http-response']
+
+=== *6-2 실패 - 유효하지 않은 닉네임*
+
+operation::follow-controller-test/search-followings-fail-nickname-blank[snippets='http-request,request-headers,http-response']
+
+=== *6-3 실패 - 유효하지 않은 마지막 id*
+
+operation::follow-controller-test/search-followings-fail-invalid-last-id[snippets='http-request,request-headers,http-response']
+
+=== *6-4 실패 - 유효하지 않은 사이즈*
+
+operation::follow-controller-test/search-followings-fail-invalid-size[snippets='http-request,request-headers,http-response']
+
+=== *6-5 실패 - 가입하지 않은 유저*
+
+operation::follow-controller-test/search-followings-fail-not-registered-user[snippets='http-request,request-headers,http-response']
+
+=== *6-5 실패 - 유효하지 않은 토큰*
+
+operation::follow-controller-test/search-followings-fail-invalid-token[snippets='http-request,request-headers,http-response']

--- a/src/docs/asciidoc/follow.adoc
+++ b/src/docs/asciidoc/follow.adoc
@@ -95,9 +95,9 @@ operation::follow-controller-test/get-follower-slice-fail-invalid-token[snippets
 
 operation::follow-controller-test/search-followings-success[snippets='http-request,request-headers,http-response']
 
-=== *6-2 실패 - 유효하지 않은 닉네임*
+=== *6-2 실패 - 닉네임이 없는 경우*
 
-operation::follow-controller-test/search-followings-fail-nickname-blank[snippets='http-request,request-headers,http-response']
+operation::follow-controller-test/search-followings-fail-nickname-null[snippets='http-request,request-headers,http-response']
 
 === *6-3 실패 - 유효하지 않은 마지막 id*
 

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -126,3 +126,30 @@ operation::user-controller-test/withdraw-user-success[snippets='http-request,req
 === *6-2 실패 - 유효하지 않은 토큰*
 
 operation::user-controller-test/withdraw-user-fail-unauthorized[snippets='http-request,request-headers,http-response']
+
+[[유저-검색-API]]
+== *7. 유저 검색 API*
+
+=== *7-1 성공*
+
+operation::user-controller-test/search-users-success[snippets='http-request,request-headers,http-response']
+
+=== *7-2 실패 - 유효하지 않은 닉네임*
+
+operation::user-controller-test/search-users-fail-nickname-blank[snippets='http-request,request-headers,http-response']
+
+=== *7-3 실패 - 유효하지 않은 마지막 id*
+
+operation::user-controller-test/search-users-fail-invalid-last-id[snippets='http-request,request-headers,http-response']
+
+=== *7-4 실패 - 유효하지 않은 사이즈*
+
+operation::user-controller-test/search-users-fail-invalid-size[snippets='http-request,request-headers,http-response']
+
+=== *7-5 실패 - 가입되지 않은 유저*
+
+operation::user-controller-test/search-users-fail-not-registered-user[snippets='http-request,request-headers,http-response']
+
+=== *7-5 실패 - 유효하지 않은 토큰*
+
+operation::user-controller-test/search-users-fail-invalid-token[snippets='http-request,request-headers,http-response']

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -132,19 +132,19 @@ operation::user-controller-test/withdraw-user-fail-unauthorized[snippets='http-r
 
 === *7-1 성공*
 
-operation::user-controller-test/search-users-success[snippets='http-request,request-headers,http-response']
+operation::user-controller-test/search-users-success[snippets='http-request,query-parameters,request-headers,http-response']
 
 === *7-2 실패 - 유효하지 않은 닉네임*
 
-operation::user-controller-test/search-users-fail-nickname-blank[snippets='http-request,request-headers,http-response']
+operation::user-controller-test/search-users-fail-nickname-blank[snippets='http-request,query-parameters,request-headers,http-response']
 
 === *7-3 실패 - 유효하지 않은 마지막 id*
 
-operation::user-controller-test/search-users-fail-invalid-last-id[snippets='http-request,request-headers,http-response']
+operation::user-controller-test/search-users-fail-invalid-last-id[snippets='http-request,query-parameters,request-headers,http-response']
 
 === *7-4 실패 - 유효하지 않은 사이즈*
 
-operation::user-controller-test/search-users-fail-invalid-size[snippets='http-request,request-headers,http-response']
+operation::user-controller-test/search-users-fail-invalid-size[snippets='http-request,query-parameters,request-headers,http-response']
 
 === *7-5 실패 - 가입되지 않은 유저*
 

--- a/src/main/kotlin/kr/weit/odya/controller/FollowController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/FollowController.kt
@@ -1,7 +1,7 @@
 package kr.weit.odya.controller
 
 import jakarta.validation.Valid
-import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Positive
 import kr.weit.odya.domain.follow.FollowSortType
 import kr.weit.odya.security.LoginUserId
@@ -81,11 +81,12 @@ class FollowController(
         return ResponseEntity.ok(followService.getSliceFollowers(userId, pageable, sortType))
     }
 
-    @GetMapping("/search")
+    @GetMapping("/followings/search")
     fun search(
         @LoginUserId userId: Long,
-        @NotBlank(message = "검색할 닉네임은 필수입니다.")
-        @RequestParam("nickname") nickname: String,
+        @NotNull(message = "검색할 닉네임은 필수입니다.")
+        @RequestParam("nickname")
+        nickname: String,
         @Positive(message = "사이즈는 양수여야 합니다.")
         @RequestParam(name = "size", required = false, defaultValue = "10")
         size: Int,
@@ -93,6 +94,6 @@ class FollowController(
         @RequestParam(name = "lastId", required = false)
         lastId: Long?,
     ): ResponseEntity<SliceResponse<FollowUserResponse>> {
-        return ResponseEntity.ok(followService.search(userId, nickname, size, lastId))
+        return ResponseEntity.ok(followService.searchByNickname(userId, nickname, size, lastId))
     }
 }

--- a/src/main/kotlin/kr/weit/odya/controller/FollowController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/FollowController.kt
@@ -1,6 +1,7 @@
 package kr.weit.odya.controller
 
 import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Positive
 import kr.weit.odya.domain.follow.FollowSortType
 import kr.weit.odya.security.LoginUserId
@@ -78,5 +79,20 @@ class FollowController(
         @RequestParam(name = "sortType", required = false, defaultValue = "LATEST") sortType: FollowSortType,
     ): ResponseEntity<SliceResponse<FollowUserResponse>> {
         return ResponseEntity.ok(followService.getSliceFollowers(userId, pageable, sortType))
+    }
+
+    @GetMapping("/search")
+    fun search(
+        @LoginUserId userId: Long,
+        @NotBlank(message = "검색할 닉네임은 필수입니다.")
+        @RequestParam("nickname") nickname: String,
+        @Positive(message = "사이즈는 양수여야 합니다.")
+        @RequestParam(name = "size", required = false, defaultValue = "10")
+        size: Int,
+        @Positive(message = "마지막 Id는 양수여야 합니다.")
+        @RequestParam(name = "lastId", required = false)
+        lastId: Long?,
+    ): ResponseEntity<SliceResponse<FollowUserResponse>> {
+        return ResponseEntity.ok(followService.search(userId, nickname, size, lastId))
     }
 }

--- a/src/main/kotlin/kr/weit/odya/controller/UserController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/UserController.kt
@@ -1,23 +1,30 @@
 package kr.weit.odya.controller
 
 import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Positive
 import kr.weit.odya.security.LoginUserId
 import kr.weit.odya.service.UserService
 import kr.weit.odya.service.WithdrawService
 import kr.weit.odya.service.dto.InformationRequest
+import kr.weit.odya.service.dto.SliceResponse
 import kr.weit.odya.service.dto.UserResponse
+import kr.weit.odya.service.dto.UserSimpleResponse
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
+@Validated
 @RestController
 @RequestMapping("/api/v1/users")
 class UserController(
@@ -76,6 +83,21 @@ class UserController(
         }
         userService.updateProfile(userId, profileName, multipartFile?.originalFilename)
         return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/search")
+    fun search(
+        @NotBlank(message = "검색할 닉네임은 필수입니다.")
+        @RequestParam("nickname")
+        nickname: String,
+        @Positive(message = "사이즈는 양수여야 합니다.")
+        @RequestParam(name = "size", required = false, defaultValue = "10")
+        size: Int,
+        @Positive(message = "마지막 Id는 양수여야 합니다.")
+        @RequestParam(name = "lastId", required = false)
+        lastId: Long?,
+    ): ResponseEntity<SliceResponse<UserSimpleResponse>> {
+        return ResponseEntity.ok(userService.search(nickname, size, lastId))
     }
 
     @DeleteMapping

--- a/src/main/kotlin/kr/weit/odya/controller/UserController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/UserController.kt
@@ -97,7 +97,7 @@ class UserController(
         @RequestParam(name = "lastId", required = false)
         lastId: Long?,
     ): ResponseEntity<SliceResponse<UserSimpleResponse>> {
-        return ResponseEntity.ok(userService.search(nickname, size, lastId))
+        return ResponseEntity.ok(userService.searchByNickname(nickname, size, lastId))
     }
 
     @DeleteMapping

--- a/src/main/kotlin/kr/weit/odya/domain/agreedTerms/AgreedTermsRepository.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/agreedTerms/AgreedTermsRepository.kt
@@ -12,4 +12,6 @@ interface AgreedTermsRepository : JpaRepository<AgreedTerms, Long> {
     fun deleteAllByUserIdAndTermsIdIn(userId: Long, termsId: Set<Long>?)
 
     fun existsByUserIdAndTermsId(userId: Long, termsId: Long): Boolean
+
+    fun deleteByUserId(userId: Long)
 }

--- a/src/main/kotlin/kr/weit/odya/domain/follow/FollowRepository.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/follow/FollowRepository.kt
@@ -23,6 +23,14 @@ fun FollowRepository.getFollowerListBySearchCond(
 ): List<Follow> =
     findSliceByFollowingIdOrderBySortType(followingId, pageable, sortType)
 
+fun FollowRepository.getByFollowerIdAndFollowingIdIn(
+    follower: Long,
+    followingIds: List<Long>,
+    size: Int,
+    lastId: Long?,
+): List<Follow> =
+    findAllByFollowerIdAndFollowingIdInAndLastId(follower, followingIds, size, lastId)
+
 interface FollowRepository : JpaRepository<Follow, Long>, CustomFollowRepository {
     fun existsByFollowerIdAndFollowingId(followerId: Long, followingId: Long): Boolean
 

--- a/src/main/kotlin/kr/weit/odya/domain/user/UserRepository.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/user/UserRepository.kt
@@ -1,5 +1,9 @@
 package kr.weit.odya.domain.user
 
+import com.linecorp.kotlinjdsl.QueryFactory
+import com.linecorp.kotlinjdsl.listQuery
+import com.linecorp.kotlinjdsl.querydsl.expression.col
+import com.linecorp.kotlinjdsl.querydsl.from.fetch
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -23,7 +27,7 @@ fun UserRepository.getByUserIdWithProfile(userId: Long): User =
 
 fun UserRepository.getByUserIds(userIds: Collection<Long>): List<User> = findByIdIn(userIds)
 
-interface UserRepository : JpaRepository<User, Long> {
+interface UserRepository : JpaRepository<User, Long>, CustomUserRepository {
     fun existsByUsername(username: String): Boolean
 
     fun existsByInformationNickname(nickname: String): Boolean
@@ -44,4 +48,22 @@ interface UserRepository : JpaRepository<User, Long> {
 
     @EntityGraph(attributePaths = ["profile", "profile.profileColor"])
     fun findUserWithProfileById(userId: Long): User?
+}
+
+interface CustomUserRepository {
+    fun findAllByUserIds(userIds: List<Long>, size: Int, lastId: Long?): List<User>
+}
+
+class CustomUserRepositoryImpl(private val queryFactory: QueryFactory) : CustomUserRepository {
+    override fun findAllByUserIds(userIds: List<Long>, size: Int, lastId: Long?): List<User> = queryFactory.listQuery {
+        select(entity(User::class))
+        from(entity(User::class))
+        where(col(entity(User::class), User::id).`in`(userIds))
+        if (lastId != null) {
+            where(col(User::id).lessThan(lastId))
+        }
+        fetch(User::profile)
+        orderBy(listOf(col(User::id).desc()))
+        limit(size)
+    }
 }

--- a/src/main/kotlin/kr/weit/odya/domain/user/UsersDocument.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/user/UsersDocument.kt
@@ -1,0 +1,22 @@
+package kr.weit.odya.domain.user
+
+import jakarta.persistence.Id
+import org.springframework.data.elasticsearch.annotations.Document
+import org.springframework.data.elasticsearch.annotations.Field
+import org.springframework.data.elasticsearch.annotations.FieldType
+import java.util.Date
+
+@Document(indexName = "#{@environment.getProperty('open-search.indices.users')}")
+data class UsersDocument(
+    @Id
+    val id: Long,
+    @Field(name = "nickname", type = FieldType.Text)
+    val nickname: String,
+    @Field(name = "@timestamp", type = FieldType.Date)
+    val createdAt: Date = Date(),
+) {
+    constructor(user: User) : this(
+        user.id,
+        user.nickname,
+    )
+}

--- a/src/main/kotlin/kr/weit/odya/domain/user/UsersDocumentRepository.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/user/UsersDocumentRepository.kt
@@ -1,0 +1,10 @@
+package kr.weit.odya.domain.user
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
+
+fun UsersDocumentRepository.getByNickname(nickname: String): List<UsersDocument> =
+    findByNicknameContainingIgnoreCaseOrderByIdDesc(nickname)
+
+interface UsersDocumentRepository : ElasticsearchRepository<UsersDocument, Long> {
+    fun findByNicknameContainingIgnoreCaseOrderByIdDesc(nickname: String): List<UsersDocument>
+}

--- a/src/main/kotlin/kr/weit/odya/service/AuthenticationService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/AuthenticationService.kt
@@ -8,6 +8,8 @@ import kr.weit.odya.domain.user.Profile
 import kr.weit.odya.domain.user.SocialType
 import kr.weit.odya.domain.user.User
 import kr.weit.odya.domain.user.UserRepository
+import kr.weit.odya.domain.user.UsersDocument
+import kr.weit.odya.domain.user.UsersDocumentRepository
 import kr.weit.odya.domain.user.existsByEmail
 import kr.weit.odya.domain.user.existsByNickname
 import kr.weit.odya.domain.user.existsByPhoneNumber
@@ -28,6 +30,7 @@ class AuthenticationService(
     private val profileColorService: ProfileColorService,
     private val firebaseTokenHelper: FirebaseTokenHelper,
     private val kakaoClient: KakaoClient,
+    private val usersDocumentRepository: UsersDocumentRepository,
 ) {
     fun appleLoginProcess(appleUsername: String) {
         if (!userRepository.existsByUsername(appleUsername)) {
@@ -53,6 +56,7 @@ class AuthenticationService(
             firebaseTokenHelper.createFirebaseUser(registerRequest.username)
         }
         termsService.saveAllAgreedTerms(user, termsIdList)
+        usersDocumentRepository.save(UsersDocument(user))
     }
 
     fun validateNickname(nickname: String) {

--- a/src/main/kotlin/kr/weit/odya/service/FollowService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/FollowService.kt
@@ -3,6 +3,7 @@ package kr.weit.odya.service
 import kr.weit.odya.domain.follow.Follow
 import kr.weit.odya.domain.follow.FollowRepository
 import kr.weit.odya.domain.follow.FollowSortType
+import kr.weit.odya.domain.follow.getByFollowerIdAndFollowingIdIn
 import kr.weit.odya.domain.follow.getFollowerListBySearchCond
 import kr.weit.odya.domain.follow.getFollowingListBySearchCond
 import kr.weit.odya.domain.user.UserRepository
@@ -78,12 +79,12 @@ class FollowService(
     }
 
     @Transactional(readOnly = true)
-    fun search(userId: Long, nickname: String, size: Int, lastId: Long?): SliceResponse<FollowUserResponse> {
+    fun searchByNickname(userId: Long, nickname: String, size: Int, lastId: Long?): SliceResponse<FollowUserResponse> {
         val usersDocuments = usersDocumentRepository.getByNickname(nickname)
         val userIds = usersDocuments.map { it.id }
 
         val followings =
-            followRepository.findAllByFollowerIdAndFollowingIdInAndLastId(userId, userIds, size + 1, lastId).map {
+            followRepository.getByFollowerIdAndFollowingIdIn(userId, userIds, size + 1, lastId).map {
                 FollowUserResponse(
                     it.following,
                     fileService.getPreAuthenticatedObjectUrl(it.following.profile.profileName),

--- a/src/main/kotlin/kr/weit/odya/service/UserService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/UserService.kt
@@ -11,6 +11,7 @@ import kr.weit.odya.domain.user.existsByPhoneNumber
 import kr.weit.odya.domain.user.getByNickname
 import kr.weit.odya.domain.user.getByUserId
 import kr.weit.odya.domain.user.getByUserIdWithProfile
+import kr.weit.odya.domain.user.getByUserIds
 import kr.weit.odya.security.FirebaseTokenHelper
 import kr.weit.odya.service.dto.InformationRequest
 import kr.weit.odya.service.dto.SliceResponse
@@ -86,10 +87,10 @@ class UserService(
         }
     }
 
-    fun search(nickname: String, size: Int, lastId: Long?): SliceResponse<UserSimpleResponse> {
+    fun searchByNickname(nickname: String, size: Int, lastId: Long?): SliceResponse<UserSimpleResponse> {
         val usersDocuments = usersDocumentRepository.getByNickname(nickname)
         val userIds = usersDocuments.map { it.id }
-        val users = userRepository.findAllByUserIds(userIds, size + 1, lastId).map {
+        val users = userRepository.getByUserIds(userIds, size + 1, lastId).map {
             UserSimpleResponse(
                 it,
                 fileService.getPreAuthenticatedObjectUrl(it.profile.profileName),

--- a/src/main/kotlin/kr/weit/odya/service/UserService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/UserService.kt
@@ -3,14 +3,19 @@ package kr.weit.odya.service
 import kr.weit.odya.domain.user.DEFAULT_PROFILE_PNG
 import kr.weit.odya.domain.user.User
 import kr.weit.odya.domain.user.UserRepository
+import kr.weit.odya.domain.user.UsersDocument
+import kr.weit.odya.domain.user.UsersDocumentRepository
 import kr.weit.odya.domain.user.existsByEmail
 import kr.weit.odya.domain.user.existsByNickname
 import kr.weit.odya.domain.user.existsByPhoneNumber
+import kr.weit.odya.domain.user.getByNickname
 import kr.weit.odya.domain.user.getByUserId
 import kr.weit.odya.domain.user.getByUserIdWithProfile
 import kr.weit.odya.security.FirebaseTokenHelper
 import kr.weit.odya.service.dto.InformationRequest
+import kr.weit.odya.service.dto.SliceResponse
 import kr.weit.odya.service.dto.UserResponse
+import kr.weit.odya.service.dto.UserSimpleResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -21,6 +26,7 @@ class UserService(
     private val firebaseTokenHelper: FirebaseTokenHelper,
     private val fileService: FileService,
     private val profileColorService: ProfileColorService,
+    private val usersDocumentRepository: UsersDocumentRepository,
 ) {
     fun getEmailByIdToken(idToken: String) = firebaseTokenHelper.getEmail(idToken)
 
@@ -57,6 +63,7 @@ class UserService(
         validateInformationRequest(informationRequest)
         val findUser = userRepository.getByUserId(userId)
         findUser.changeInformation(informationRequest.nickname)
+        usersDocumentRepository.save(UsersDocument(findUser))
     }
 
     fun uploadProfile(profile: MultipartFile): String = fileService.saveFile(profile)
@@ -77,6 +84,18 @@ class UserService(
                 getProfileColor(profileName),
             )
         }
+    }
+
+    fun search(nickname: String, size: Int, lastId: Long?): SliceResponse<UserSimpleResponse> {
+        val usersDocuments = usersDocumentRepository.getByNickname(nickname)
+        val userIds = usersDocuments.map { it.id }
+        val users = userRepository.findAllByUserIds(userIds, size + 1, lastId).map {
+            UserSimpleResponse(
+                it,
+                fileService.getPreAuthenticatedObjectUrl(it.profile.profileName),
+            )
+        }
+        return SliceResponse(size, users)
     }
 
     private fun getProfileColor(profileName: String?) = if (profileName == null) {

--- a/src/main/kotlin/kr/weit/odya/service/WithdrawService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/WithdrawService.kt
@@ -1,10 +1,12 @@
 package kr.weit.odya.service
 
+import kr.weit.odya.domain.agreedTerms.AgreedTermsRepository
 import kr.weit.odya.domain.favoritePlace.FavoritePlaceRepository
 import kr.weit.odya.domain.favoriteTopic.FavoriteTopicRepository
 import kr.weit.odya.domain.follow.FollowRepository
 import kr.weit.odya.domain.placeReview.PlaceReviewRepository
 import kr.weit.odya.domain.user.UserRepository
+import kr.weit.odya.domain.user.UsersDocumentRepository
 import kr.weit.odya.domain.user.getByUserId
 import kr.weit.odya.security.FirebaseTokenHelper
 import org.springframework.stereotype.Service
@@ -18,20 +20,20 @@ class WithdrawService(
     private val placeReviewRepository: PlaceReviewRepository,
     private val favoriteTopicRepository: FavoriteTopicRepository,
     private val firebaseTokenHelper: FirebaseTokenHelper,
+    private val usersDocumentRepository: UsersDocumentRepository,
+    private val agreedTermsRepository: AgreedTermsRepository,
 ) {
     @Transactional
     fun withdrawUser(userId: Long) {
         val uid = userRepository.getByUserId(userId).username
-        runCatching {
-            favoritePlaceRepository.deleteByUserId(userId)
-            followRepository.deleteByFollowingId(userId)
-            followRepository.deleteByFollowerId(userId)
-            placeReviewRepository.deleteByUserId(userId)
-            favoriteTopicRepository.deleteByUserId(userId)
-            userRepository.deleteById(userId)
-        }.onFailure {
-            throw RuntimeException("회원 탈퇴 중 오류가 발생했습니다")
-        }
+        favoritePlaceRepository.deleteByUserId(userId)
+        followRepository.deleteByFollowingId(userId)
+        followRepository.deleteByFollowerId(userId)
+        placeReviewRepository.deleteByUserId(userId)
+        favoriteTopicRepository.deleteByUserId(userId)
+        agreedTermsRepository.deleteByUserId(userId)
+        userRepository.deleteById(userId)
+        usersDocumentRepository.deleteById(userId)
         firebaseTokenHelper.withdrawUser(uid)
     }
 }

--- a/src/main/kotlin/kr/weit/odya/service/dto/PlaceReviewDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/service/dto/PlaceReviewDtos.kt
@@ -71,14 +71,11 @@ data class SlicePlaceReviewResponse private constructor(
 ) : SliceResponse<PlaceReviewListResponse>(hasNext, content) {
     companion object {
         fun of(size: Int, content: List<PlaceReview>, averageRating: Double): SlicePlaceReviewResponse {
-            val contents: List<PlaceReview>
-            val hasNext: Boolean
-            if (content.size > size) {
-                hasNext = true
-                contents = content.dropLast(1)
+            val hasNext: Boolean = content.size > size
+            val contents = if (hasNext) {
+                content.dropLast(1)
             } else {
-                hasNext = false
-                contents = content
+                content
             }
             return SlicePlaceReviewResponse(hasNext, averageRating, contents.map { PlaceReviewListResponse(it) })
         }

--- a/src/main/kotlin/kr/weit/odya/service/dto/SliceDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/service/dto/SliceDtos.kt
@@ -6,8 +6,10 @@ open class SliceResponse<T>(
     open val hasNext: Boolean,
     open val content: List<T>,
 ) {
-    constructor(pageable: Pageable, content: List<T>) : this(
-        content.size > pageable.pageSize,
-        if (content.size > pageable.pageSize) content.dropLast(1) else content,
+    constructor(size: Int, content: List<T>) : this(
+        content.size > size,
+        if (content.size > size) content.dropLast(1) else content,
     )
+
+    constructor(pageable: Pageable, content: List<T>) : this(pageable.pageSize, content)
 }

--- a/src/main/kotlin/kr/weit/odya/service/dto/UsersDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/service/dto/UsersDtos.kt
@@ -60,3 +60,41 @@ data class UserProfileResponse(
         )
     }
 }
+
+data class UserSimpleResponse(
+    val userId: Long,
+    val nickname: String,
+    val profile: ProfileResponse,
+) {
+    constructor(user: User, profileUrl: String) : this(
+        user.id,
+        user.nickname,
+        ProfileResponse(
+            profileUrl,
+            if (user.profile.profileColor.colorHex != NONE_PROFILE_COLOR_HEX) {
+                ProfileResponse.ProfileColorResponse(user.profile.profileColor)
+            } else {
+                null
+            },
+        ),
+    )
+}
+
+data class ProfileResponse(
+    val profileUrl: String,
+    val profileColor: ProfileColorResponse?,
+) {
+    data class ProfileColorResponse(
+        val colorHex: String,
+        val red: Int,
+        val green: Int,
+        val blue: Int,
+    ) {
+        constructor(profileColor: ProfileColor) : this(
+            profileColor.colorHex,
+            profileColor.red,
+            profileColor.green,
+            profileColor.blue,
+        )
+    }
+}

--- a/src/main/resources/application-open-search.yml
+++ b/src/main/resources/application-open-search.yml
@@ -4,6 +4,7 @@ spring.config.activate.on-profile: sandbox
 open-search:
   indices:
     place-search-history: sandbox-place-search-history
+    users: sandbox-users
 
 ---
 spring.config.activate.on-profile: stable
@@ -11,3 +12,4 @@ spring.config.activate.on-profile: stable
 open-search:
   indices:
     place-search-history: stable-place-search-history
+    users: stable-users

--- a/src/test/kotlin/kr/weit/odya/controller/FollowControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/FollowControllerTest.kt
@@ -565,11 +565,11 @@ class FollowControllerTest(
             }
         }
 
-        describe("GET /api/v1/follows/search") {
-            val targetUri = "/api/v1/follows/search"
+        describe("GET /api/v1/follows/followings/search") {
+            val targetUri = "/api/v1/follows/followings/search"
             context("유효한 토큰이면서, 가입된 사용자인 경우") {
                 val response = createFollowSlice()
-                every { followService.search(TEST_USER_ID, TEST_NICKNAME, TEST_SIZE, TEST_LAST_ID) } returns response
+                every { followService.searchByNickname(TEST_USER_ID, TEST_NICKNAME, TEST_SIZE, TEST_LAST_ID) } returns response
                 it("200 응답한다.") {
                     restDocMockMvc.get(targetUri) {
                         header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
@@ -605,25 +605,23 @@ class FollowControllerTest(
                 }
             }
 
-            context("유효한 토큰이면서, 닉네임이 올바르지 않은 경우") {
+            context("유효한 토큰이면서, 닉네임이 없는 경우") {
                 it("400 응답한다.") {
                     restDocMockMvc.get(targetUri) {
                         header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
                         param(SIZE_PARAM, TEST_SIZE.toString())
-                        param(NICKNAME_PARAM, " ")
                         param(LAST_ID_PARAM, TEST_LAST_ID.toString())
                     }.andExpect {
                         status { isBadRequest() }
                     }.andDo {
                         createDocument(
-                            "search-followings-fail-nickname-blank",
+                            "search-followings-fail-nickname-null",
                             requestHeaders(
                                 HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                             ),
                             queryParameters(
                                 SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
                                 LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                NICKNAME_PARAM parameterDescription "올바르지 않은 닉네임" example " ",
                             ),
                         )
                     }

--- a/src/test/kotlin/kr/weit/odya/controller/FollowControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/FollowControllerTest.kt
@@ -10,13 +10,20 @@ import kr.weit.odya.service.ExistResourceException
 import kr.weit.odya.service.FollowService
 import kr.weit.odya.service.ObjectStorageException
 import kr.weit.odya.support.ALREADY_FOLLOW_ERROR_MESSAGE
+import kr.weit.odya.support.LAST_ID_PARAM
+import kr.weit.odya.support.NICKNAME_PARAM
 import kr.weit.odya.support.PAGE_PARAM
 import kr.weit.odya.support.SIZE_PARAM
 import kr.weit.odya.support.SOMETHING_ERROR_MESSAGE
 import kr.weit.odya.support.SORT_TYPE_PARAM
 import kr.weit.odya.support.TEST_BEARER_ID_TOKEN
 import kr.weit.odya.support.TEST_BEARER_INVALID_ID_TOKEN
+import kr.weit.odya.support.TEST_BEARER_NOT_EXIST_USER_ID_TOKEN
+import kr.weit.odya.support.TEST_INVALID_LAST_ID
+import kr.weit.odya.support.TEST_INVALID_SIZE
 import kr.weit.odya.support.TEST_INVALID_USER_ID
+import kr.weit.odya.support.TEST_LAST_ID
+import kr.weit.odya.support.TEST_NICKNAME
 import kr.weit.odya.support.TEST_PAGE
 import kr.weit.odya.support.TEST_PAGEABLE
 import kr.weit.odya.support.TEST_SIZE
@@ -47,6 +54,7 @@ import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.restdocs.request.RequestDocumentation.queryParameters
 import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.web.context.WebApplicationContext
@@ -553,6 +561,162 @@ class FollowControllerTest(
                                 ),
                             ),
                         )
+                }
+            }
+        }
+
+        describe("GET /api/v1/follows/search") {
+            val targetUri = "/api/v1/follows/search"
+            context("유효한 토큰이면서, 가입된 사용자인 경우") {
+                val response = createFollowSlice()
+                every { followService.search(TEST_USER_ID, TEST_NICKNAME, TEST_SIZE, TEST_LAST_ID) } returns response
+                it("200 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(SIZE_PARAM, TEST_SIZE.toString())
+                        param(NICKNAME_PARAM, TEST_NICKNAME)
+                        param(LAST_ID_PARAM, TEST_LAST_ID.toString())
+                    }.andExpect {
+                        status { isOk() }
+                    }.andDo {
+                        val content = response.content[0]
+                        createDocument(
+                            "search-followings-success",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example "null" isOptional true,
+                                LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example "null" isOptional true,
+                                NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
+                            ),
+                            responseBody(
+                                "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
+                                "content[].userId" type JsonFieldType.NUMBER description "사용자 ID" example content.userId,
+                                "content[].nickname" type JsonFieldType.STRING description "사용자 닉네임" example content.nickname,
+                                "content[].profile.profileUrl" type JsonFieldType.STRING description "사용자 프로필 Url" example content.profile.profileUrl,
+                                "content[].profile.profileColor.colorHex" type JsonFieldType.STRING description "색상 Hex" example content.profile.profileColor?.colorHex isOptional true,
+                                "content[].profile.profileColor.red" type JsonFieldType.NUMBER description "RGB RED" example content.profile.profileColor?.red isOptional true,
+                                "content[].profile.profileColor.green" type JsonFieldType.NUMBER description "RGB GREEN" example content.profile.profileColor?.green isOptional true,
+                                "content[].profile.profileColor.blue" type JsonFieldType.NUMBER description "RGB BLUE" example content.profile.profileColor?.blue isOptional true,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효한 토큰이면서, 닉네임이 올바르지 않은 경우") {
+                it("400 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(SIZE_PARAM, TEST_SIZE.toString())
+                        param(NICKNAME_PARAM, " ")
+                        param(LAST_ID_PARAM, TEST_LAST_ID.toString())
+                    }.andExpect {
+                        status { isBadRequest() }
+                    }.andDo {
+                        createDocument(
+                            "search-followings-fail-nickname-blank",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                NICKNAME_PARAM parameterDescription "올바르지 않은 닉네임" example " ",
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효한 토큰이지만 조회할 마지막 ID가 양수가 아닌 경우") {
+                it("400 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(SIZE_PARAM, TEST_SIZE.toString())
+                        param(NICKNAME_PARAM, TEST_NICKNAME)
+                        param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString())
+                    }.andExpect {
+                        status { isBadRequest() }
+                    }.andDo {
+                        createDocument(
+                            "search-followings-fail-invalid-last-id",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                LAST_ID_PARAM parameterDescription "양수가 아닌 마지막 데이터의 ID" example TEST_INVALID_LAST_ID isOptional true,
+                                NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효한 토큰이지만 size가 양수가 아닌 경우") {
+                it("400 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
+                        param(NICKNAME_PARAM, TEST_NICKNAME)
+                        param(LAST_ID_PARAM, TEST_LAST_ID.toString())
+                    }.andExpect {
+                        status { isBadRequest() }
+                    }.andDo {
+                        createDocument(
+                            "search-followings-fail-invalid-size",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "양수가 아닌 데이터 개수" example TEST_INVALID_SIZE isOptional true,
+                                LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효한 토큰이면서, 가입되지 않은 사용자인 경우") {
+                it("401 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN)
+                        param(SIZE_PARAM, TEST_SIZE.toString())
+                        param(NICKNAME_PARAM, TEST_NICKNAME)
+                        param(LAST_ID_PARAM, TEST_LAST_ID.toString())
+                    }.andExpect {
+                        status { isUnauthorized() }
+                    }.andDo {
+                        createDocument(
+                            "search-followings-fail-not-registered-user",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효하지 않은 토큰이면") {
+                it("401 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                        param(SIZE_PARAM, TEST_SIZE.toString())
+                        param(NICKNAME_PARAM, TEST_NICKNAME)
+                        param(LAST_ID_PARAM, TEST_LAST_ID.toString())
+                    }.andExpect {
+                        status { isUnauthorized() }
+                    }.andDo {
+                        createDocument(
+                            "search-followings-fail-invalid-token",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                            ),
+                        )
+                    }
                 }
             }
         }

--- a/src/test/kotlin/kr/weit/odya/controller/UserControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/UserControllerTest.kt
@@ -690,7 +690,7 @@ class UserControllerTest(
             val targetUri = "/api/v1/users/search"
             context("유효한 토큰이면서, 가입된 사용자인 경우") {
                 val response = createSliceSimpleUserResponse()
-                every { userService.search(TEST_NICKNAME, TEST_SIZE, TEST_LAST_ID) } returns response
+                every { userService.searchByNickname(TEST_NICKNAME, TEST_SIZE, TEST_LAST_ID) } returns response
                 it("200 응답한다.") {
                     restDocMockMvc.get(targetUri) {
                         header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)

--- a/src/test/kotlin/kr/weit/odya/domain/follow/FollowRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/odya/domain/follow/FollowRepositoryTest.kt
@@ -88,7 +88,7 @@ class FollowRepositoryTest(
         context("팔로잉 유저 id list 검색") {
             expect("팔로잉 id list에 해당하는 팔로잉 유저를 조회한다") {
                 val userIds = listOf(following.id, following.id + 1)
-                val result = followRepository.findAllByFollowerIdAndFollowingIdInAndLastId(
+                val result = followRepository.getByFollowerIdAndFollowingIdIn(
                     follower.id,
                     userIds,
                     TEST_DEFAULT_SIZE,
@@ -100,20 +100,20 @@ class FollowRepositoryTest(
             expect("팔로잉 id list에 해당하는 팔로잉 유저를 size만큼 조회한다") {
                 val userIds = listOf(following.id, following.id + 1)
                 val result =
-                    followRepository.findAllByFollowerIdAndFollowingIdInAndLastId(follower.id, userIds, 1, null)
+                    followRepository.getByFollowerIdAndFollowingIdIn(follower.id, userIds, 1, null)
                 result.size shouldBe 1
             }
 
             expect("팔로잉 id list에 해당하는 lastId보다 작은 팔로잉 유저를 조회한다") {
                 val userIds = listOf(following.id, following.id + 1)
-                var result = followRepository.findAllByFollowerIdAndFollowingIdInAndLastId(
+                var result = followRepository.getByFollowerIdAndFollowingIdIn(
                     follower.id,
                     userIds,
                     TEST_DEFAULT_SIZE,
                     following.id + 1,
                 )
                 result.size shouldBe 1
-                result = followRepository.findAllByFollowerIdAndFollowingIdInAndLastId(
+                result = followRepository.getByFollowerIdAndFollowingIdIn(
                     follower.id,
                     userIds,
                     TEST_DEFAULT_SIZE,

--- a/src/test/kotlin/kr/weit/odya/domain/user/UserRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/odya/domain/user/UserRepositoryTest.kt
@@ -3,6 +3,7 @@ package kr.weit.odya.domain.user
 import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.matchers.shouldBe
 import kr.weit.odya.support.TEST_DEFAULT_PROFILE_PNG
+import kr.weit.odya.support.TEST_DEFAULT_SIZE
 import kr.weit.odya.support.TEST_EMAIL
 import kr.weit.odya.support.TEST_NICKNAME
 import kr.weit.odya.support.TEST_OTHER_USER_ID
@@ -73,6 +74,28 @@ class UserRepositoryTest(
                 val userIds = listOf(TEST_USER_ID, TEST_OTHER_USER_ID)
                 val result = userRepository.existsAllByUserIds(userIds, userIds.size)
                 result shouldBe true
+            }
+        }
+
+        context("사용자 id list 검색") {
+            expect("사용자 id list에 해당하는 사용자를 조회한다") {
+                val userIds = listOf(TEST_USER_ID, TEST_OTHER_USER_ID)
+                val result = userRepository.findAllByUserIds(userIds, TEST_DEFAULT_SIZE, null)
+                result.size shouldBe 2
+            }
+
+            expect("사용자 id list에 해당하는 사용자를 size만큼 조회한다") {
+                val userIds = listOf(TEST_USER_ID, TEST_OTHER_USER_ID)
+                val result = userRepository.findAllByUserIds(userIds, 1, null)
+                result.size shouldBe 1
+            }
+
+            expect("사용자 id list에 해당하는 lastId보다 작은 유저를 조회한다") {
+                val userIds = listOf(TEST_USER_ID, TEST_OTHER_USER_ID)
+                var result = userRepository.findAllByUserIds(userIds, TEST_DEFAULT_SIZE, TEST_OTHER_USER_ID)
+                result.size shouldBe 1
+                result = userRepository.findAllByUserIds(userIds, TEST_DEFAULT_SIZE, TEST_USER_ID)
+                result.size shouldBe 0
             }
         }
     },

--- a/src/test/kotlin/kr/weit/odya/domain/user/UserRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/odya/domain/user/UserRepositoryTest.kt
@@ -80,21 +80,21 @@ class UserRepositoryTest(
         context("사용자 id list 검색") {
             expect("사용자 id list에 해당하는 사용자를 조회한다") {
                 val userIds = listOf(TEST_USER_ID, TEST_OTHER_USER_ID)
-                val result = userRepository.findAllByUserIds(userIds, TEST_DEFAULT_SIZE, null)
+                val result = userRepository.getByUserIds(userIds, TEST_DEFAULT_SIZE, null)
                 result.size shouldBe 2
             }
 
             expect("사용자 id list에 해당하는 사용자를 size만큼 조회한다") {
                 val userIds = listOf(TEST_USER_ID, TEST_OTHER_USER_ID)
-                val result = userRepository.findAllByUserIds(userIds, 1, null)
+                val result = userRepository.getByUserIds(userIds, 1, null)
                 result.size shouldBe 1
             }
 
             expect("사용자 id list에 해당하는 lastId보다 작은 유저를 조회한다") {
                 val userIds = listOf(TEST_USER_ID, TEST_OTHER_USER_ID)
-                var result = userRepository.findAllByUserIds(userIds, TEST_DEFAULT_SIZE, TEST_OTHER_USER_ID)
+                var result = userRepository.getByUserIds(userIds, TEST_DEFAULT_SIZE, TEST_OTHER_USER_ID)
                 result.size shouldBe 1
-                result = userRepository.findAllByUserIds(userIds, TEST_DEFAULT_SIZE, TEST_USER_ID)
+                result = userRepository.getByUserIds(userIds, TEST_DEFAULT_SIZE, TEST_USER_ID)
                 result.size shouldBe 0
             }
         }

--- a/src/test/kotlin/kr/weit/odya/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/AuthenticationServiceTest.kt
@@ -10,6 +10,8 @@ import io.mockk.mockk
 import io.mockk.runs
 import kr.weit.odya.client.kakao.KakaoClient
 import kr.weit.odya.domain.user.UserRepository
+import kr.weit.odya.domain.user.UsersDocument
+import kr.weit.odya.domain.user.UsersDocumentRepository
 import kr.weit.odya.domain.user.existsByEmail
 import kr.weit.odya.domain.user.existsByNickname
 import kr.weit.odya.domain.user.existsByPhoneNumber
@@ -26,6 +28,7 @@ import kr.weit.odya.support.TEST_KAKAO_UID
 import kr.weit.odya.support.TEST_NICKNAME
 import kr.weit.odya.support.TEST_PHONE_NUMBER
 import kr.weit.odya.support.TEST_USERNAME
+import kr.weit.odya.support.TEST_USER_ID
 import kr.weit.odya.support.createAppleRegisterRequest
 import kr.weit.odya.support.createKakaoLoginRequest
 import kr.weit.odya.support.createKakaoUserInfo
@@ -39,9 +42,17 @@ class AuthenticationServiceTest : DescribeSpec(
         val profileColorService = mockk<ProfileColorService>()
         val kakaoClient = mockk<KakaoClient>()
         val termsService = mockk<TermsService>()
+        val usersDocumentRepository = mockk<UsersDocumentRepository>()
 
         val authenticationService =
-            AuthenticationService(termsService, userRepository, profileColorService, firebaseTokenHelper, kakaoClient)
+            AuthenticationService(
+                termsService,
+                userRepository,
+                profileColorService,
+                firebaseTokenHelper,
+                kakaoClient,
+                usersDocumentRepository,
+            )
 
         describe("appleLoginProcess") {
             context("유효한 USERNAME이 주어지는 경우") {
@@ -100,6 +111,7 @@ class AuthenticationServiceTest : DescribeSpec(
                 every { userRepository.save(any()) } returns createUser()
                 every { termsService.checkRequiredTerms(request.termsIdList) } just runs
                 every { termsService.saveAllAgreedTerms(any(), request.termsIdList) } just runs
+                every { usersDocumentRepository.save(any()) } returns UsersDocument(TEST_USER_ID, request.nickname)
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny { authenticationService.register(request) }
                 }

--- a/src/test/kotlin/kr/weit/odya/service/FollowServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/FollowServiceTest.kt
@@ -9,6 +9,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import kr.weit.odya.domain.follow.FollowRepository
+import kr.weit.odya.domain.follow.getByFollowerIdAndFollowingIdIn
 import kr.weit.odya.domain.follow.getFollowerListBySearchCond
 import kr.weit.odya.domain.follow.getFollowingListBySearchCond
 import kr.weit.odya.domain.user.UserRepository
@@ -187,12 +188,12 @@ class FollowServiceTest : DescribeSpec(
             }
         }
 
-        describe("search") {
+        describe("searchByNickname") {
             context("유효한 nickname이 주어지면") {
                 val user = createUser()
                 every { usersDocumentRepository.getByNickname(TEST_NICKNAME) } returns listOf(createUsersDocument(user))
                 every {
-                    followRepository.findAllByFollowerIdAndFollowingIdInAndLastId(
+                    followRepository.getByFollowerIdAndFollowingIdIn(
                         any(),
                         any(),
                         any(),
@@ -201,7 +202,7 @@ class FollowServiceTest : DescribeSpec(
                 } returns listOf(createFollow(following = user))
                 every { fileService.getPreAuthenticatedObjectUrl(TEST_DEFAULT_PROFILE_PNG) } returns TEST_PROFILE_URL
                 it("유저를 조회 한다") {
-                    shouldNotThrowAny { followService.search(TEST_USER_ID, TEST_NICKNAME, 10, null) }
+                    shouldNotThrowAny { followService.searchByNickname(TEST_USER_ID, TEST_NICKNAME, 10, null) }
                 }
             }
         }

--- a/src/test/kotlin/kr/weit/odya/service/FollowServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/FollowServiceTest.kt
@@ -12,6 +12,7 @@ import kr.weit.odya.domain.follow.FollowRepository
 import kr.weit.odya.domain.follow.getFollowerListBySearchCond
 import kr.weit.odya.domain.follow.getFollowingListBySearchCond
 import kr.weit.odya.domain.user.UserRepository
+import kr.weit.odya.domain.user.UsersDocumentRepository
 import kr.weit.odya.domain.user.getByUserId
 import kr.weit.odya.support.SOMETHING_ERROR_MESSAGE
 import kr.weit.odya.support.TEST_DEFAULT_PAGEABLE
@@ -34,7 +35,9 @@ class FollowServiceTest : DescribeSpec(
         val userRepository = mockk<UserRepository>()
         val followRepository = mockk<FollowRepository>()
         val objectStorageService = mockk<ObjectStorageService>()
-        val followService = FollowService(followRepository, userRepository, objectStorageService)
+        val usersDocumentRepository = mockk<UsersDocumentRepository>()
+        val followService =
+            FollowService(followRepository, userRepository, objectStorageService, usersDocumentRepository)
 
         describe("createFollow") {
             context("이미 존재하지 않는 팔로우를 생성하는 경우") {

--- a/src/test/kotlin/kr/weit/odya/service/UserServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/UserServiceTest.kt
@@ -17,6 +17,7 @@ import kr.weit.odya.domain.user.existsByPhoneNumber
 import kr.weit.odya.domain.user.getByNickname
 import kr.weit.odya.domain.user.getByUserId
 import kr.weit.odya.domain.user.getByUserIdWithProfile
+import kr.weit.odya.domain.user.getByUserIds
 import kr.weit.odya.security.FirebaseTokenHelper
 import kr.weit.odya.security.InvalidTokenException
 import kr.weit.odya.support.DELETE_NOT_EXIST_PROFILE_ERROR_MESSAGE
@@ -318,14 +319,14 @@ class UserServiceTest : DescribeSpec(
             }
         }
 
-        describe("search") {
+        describe("searchByNickname") {
             context("유효한 nickname이 주어지면") {
                 val user = createUser()
                 every { usersDocumentRepository.getByNickname(TEST_NICKNAME) } returns listOf(createUsersDocument(user))
-                every { userRepository.findAllByUserIds(any(), any(), any()) } returns listOf(user)
+                every { userRepository.getByUserIds(any(), any(), any()) } returns listOf(user)
                 every { fileService.getPreAuthenticatedObjectUrl(TEST_DEFAULT_PROFILE_PNG) } returns TEST_PROFILE_URL
                 it("유저를 조회 한다") {
-                    shouldNotThrowAny { userService.search(TEST_NICKNAME, 10, null) }
+                    shouldNotThrowAny { userService.searchByNickname(TEST_NICKNAME, 10, null) }
                 }
             }
         }

--- a/src/test/kotlin/kr/weit/odya/service/UserServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/UserServiceTest.kt
@@ -9,6 +9,8 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import kr.weit.odya.domain.user.UserRepository
+import kr.weit.odya.domain.user.UsersDocument
+import kr.weit.odya.domain.user.UsersDocumentRepository
 import kr.weit.odya.domain.user.existsByEmail
 import kr.weit.odya.domain.user.existsByNickname
 import kr.weit.odya.domain.user.existsByPhoneNumber
@@ -41,7 +43,9 @@ class UserServiceTest : DescribeSpec(
         val firebaseTokenHelper = mockk<FirebaseTokenHelper>()
         val fileService = mockk<FileService>()
         val profileColorService = mockk<ProfileColorService>()
-        val userService = UserService(userRepository, firebaseTokenHelper, fileService, profileColorService)
+        val usersDocumentRepository = mockk<UsersDocumentRepository>()
+        val userService =
+            UserService(userRepository, firebaseTokenHelper, fileService, profileColorService, usersDocumentRepository)
 
         describe("getInformation") {
             context("가입되어 있는 USER ID가 주어지는 경우") {
@@ -178,6 +182,7 @@ class UserServiceTest : DescribeSpec(
             context("가입되어 있는 USER ID와 유효한 정보 요청이 주어지는 경우") {
                 every { userRepository.existsByNickname(TEST_NICKNAME) } returns false
                 every { userRepository.getByUserId(TEST_USER_ID) } returns createUser()
+                every { usersDocumentRepository.save(any()) } returns UsersDocument(TEST_USER_ID, TEST_NICKNAME)
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny { userService.updateInformation(TEST_USER_ID, informationRequest) }
                 }

--- a/src/test/kotlin/kr/weit/odya/service/UserServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/UserServiceTest.kt
@@ -14,6 +14,7 @@ import kr.weit.odya.domain.user.UsersDocumentRepository
 import kr.weit.odya.domain.user.existsByEmail
 import kr.weit.odya.domain.user.existsByNickname
 import kr.weit.odya.domain.user.existsByPhoneNumber
+import kr.weit.odya.domain.user.getByNickname
 import kr.weit.odya.domain.user.getByUserId
 import kr.weit.odya.domain.user.getByUserIdWithProfile
 import kr.weit.odya.security.FirebaseTokenHelper
@@ -36,6 +37,7 @@ import kr.weit.odya.support.createNoneProfileColor
 import kr.weit.odya.support.createProfileColor
 import kr.weit.odya.support.createUser
 import kr.weit.odya.support.createUserResponse
+import kr.weit.odya.support.createUsersDocument
 
 class UserServiceTest : DescribeSpec(
     {
@@ -312,6 +314,18 @@ class UserServiceTest : DescribeSpec(
                     shouldThrow<NoSuchElementException> {
                         userService.updateProfile(TEST_USER_ID, TEST_PROFILE_WEBP, TEST_PROFILE_WEBP)
                     }
+                }
+            }
+        }
+
+        describe("search") {
+            context("유효한 nickname이 주어지면") {
+                val user = createUser()
+                every { usersDocumentRepository.getByNickname(TEST_NICKNAME) } returns listOf(createUsersDocument(user))
+                every { userRepository.findAllByUserIds(any(), any(), any()) } returns listOf(user)
+                every { fileService.getPreAuthenticatedObjectUrl(TEST_DEFAULT_PROFILE_PNG) } returns TEST_PROFILE_URL
+                it("유저를 조회 한다") {
+                    shouldNotThrowAny { userService.search(TEST_NICKNAME, 10, null) }
                 }
             }
         }

--- a/src/test/kotlin/kr/weit/odya/service/WithdrawServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/WithdrawServiceTest.kt
@@ -7,11 +7,13 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import kr.weit.odya.domain.agreedTerms.AgreedTermsRepository
 import kr.weit.odya.domain.favoritePlace.FavoritePlaceRepository
 import kr.weit.odya.domain.favoriteTopic.FavoriteTopicRepository
 import kr.weit.odya.domain.follow.FollowRepository
 import kr.weit.odya.domain.placeReview.PlaceReviewRepository
 import kr.weit.odya.domain.user.UserRepository
+import kr.weit.odya.domain.user.UsersDocumentRepository
 import kr.weit.odya.domain.user.getByUserId
 import kr.weit.odya.security.FirebaseTokenHelper
 import kr.weit.odya.support.TEST_USERNAME
@@ -26,6 +28,8 @@ class WithdrawServiceTest : DescribeSpec(
         val placeReviewRepository = mockk<PlaceReviewRepository>()
         val favoriteTopicRepository = mockk<FavoriteTopicRepository>()
         val firebaseTokenHelper = mockk<FirebaseTokenHelper>()
+        val usersDocumentRepository = mockk<UsersDocumentRepository>()
+        val agreedTermsRepository = mockk<AgreedTermsRepository>()
         val withdrawService =
             WithdrawService(
                 userRepository,
@@ -34,6 +38,8 @@ class WithdrawServiceTest : DescribeSpec(
                 placeReviewRepository,
                 favoriteTopicRepository,
                 firebaseTokenHelper,
+                usersDocumentRepository,
+                agreedTermsRepository,
             )
 
         describe("withdrawUser") {
@@ -46,6 +52,8 @@ class WithdrawServiceTest : DescribeSpec(
                 every { favoriteTopicRepository.deleteByUserId(any()) } just runs
                 every { userRepository.deleteById(TEST_USER_ID) } just runs
                 every { firebaseTokenHelper.withdrawUser(TEST_USERNAME) } just runs
+                every { usersDocumentRepository.deleteById(TEST_USER_ID) } just runs
+                every { agreedTermsRepository.deleteByUserId(TEST_USER_ID) } just runs
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny { withdrawService.withdrawUser(TEST_USER_ID) }
                 }
@@ -60,6 +68,8 @@ class WithdrawServiceTest : DescribeSpec(
                 every { favoriteTopicRepository.deleteByUserId(any()) } just runs
                 every { userRepository.deleteById(TEST_USER_ID) } just runs
                 every { firebaseTokenHelper.withdrawUser(TEST_USERNAME) } just runs
+                every { usersDocumentRepository.deleteById(TEST_USER_ID) } just runs
+                every { agreedTermsRepository.deleteByUserId(TEST_USER_ID) } just runs
                 it("[NoSuchElementException] 반환") {
                     shouldThrow<NoSuchElementException> { withdrawService.withdrawUser(TEST_USER_ID) }
                 }

--- a/src/test/kotlin/kr/weit/odya/support/ParamFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/ParamFixtures.kt
@@ -7,6 +7,7 @@ const val PAGE_PARAM = "page"
 const val SIZE_PARAM = "size"
 const val SORT_TYPE_PARAM = "sortType"
 const val LAST_ID_PARAM = "lastId"
+const val NICKNAME_PARAM = "nickname"
 const val TEST_DEFAULT_PAGE = 0
 const val TEST_DEFAULT_SIZE = 10
 const val TEST_PAGE: Int = 1

--- a/src/test/kotlin/kr/weit/odya/support/UserFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/UserFixtures.kt
@@ -5,8 +5,11 @@ import kr.weit.odya.domain.user.Profile
 import kr.weit.odya.domain.user.SocialType
 import kr.weit.odya.domain.user.User
 import kr.weit.odya.domain.user.UserRole
+import kr.weit.odya.domain.user.UsersDocument
 import kr.weit.odya.service.dto.InformationRequest
+import kr.weit.odya.service.dto.SliceResponse
 import kr.weit.odya.service.dto.UserResponse
+import kr.weit.odya.service.dto.UserSimpleResponse
 import java.time.LocalDate
 
 const val TEST_USER_ID = 1L
@@ -62,4 +65,19 @@ fun createProfile(profileId: Long = 0L, profileName: String = TEST_DEFAULT_PROFI
     id = profileId,
     profileName = profileName,
     profileColor = createProfileColor(TEST_PROFILE_COLOR_ID),
+)
+
+fun createUsersDocument(user: User = createUser()): UsersDocument = UsersDocument(user)
+
+fun createSimpleUserResponse(user: User = createUser(), profileUrl: String = TEST_PROFILE_URL): UserSimpleResponse =
+    UserSimpleResponse(
+        user = user,
+        profileUrl = profileUrl,
+    )
+
+fun createSliceSimpleUserResponse() = SliceResponse(
+    hasNext = false,
+    content = listOf(
+        createSimpleUserResponse(),
+    ),
 )

--- a/src/test/kotlin/kr/weit/odya/support/config/TestMockBeanConfig.kt
+++ b/src/test/kotlin/kr/weit/odya/support/config/TestMockBeanConfig.kt
@@ -1,6 +1,7 @@
 package kr.weit.odya.support.config
 
 import kr.weit.odya.domain.placeSearchHistory.PlaceSearchHistoryRepository
+import kr.weit.odya.domain.user.UsersDocumentRepository
 import kr.weit.odya.service.ObjectStorageService
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -12,4 +13,7 @@ class TestMockBeanConfig {
 
     @MockBean
     lateinit var placeSearchHistoryRepository: PlaceSearchHistoryRepository
+
+    @MockBean
+    lateinit var usersDocumentRepository: UsersDocumentRepository
 }


### PR DESCRIPTION
### 개요
- 사용자를 검색하는 기능이 필요하다

### 변경사항
- 유저를 닉네임으로 검색하는 기능 추가
- 팔로잉 유저를 닉네임으로 검색하는 기능 추가
- 유저가 탈퇴할때 동의한 약관 이력을 삭제하지 않아 에러가 발생하고있던 버그도 같이 수정

### 관련 지라 및 위키 링크
- [ODYA-118](https://weit.atlassian.net/browse/ODYA-118)

### 리뷰어에게 하고 싶은 말
- 개발보다 테스트 작성에 오래 걸린건 정말 오랜만이네요 ㅋㅋㅋㅋㅋ
- 도대체 두분은 지금까지 무슨 싸움을 하고계셨겁니까..! 고생이 진짜 많으셨겠네요 ㅋㅋ큐ㅠㅠ
