### PR TITLE
ODYA-127 알수도 있는 친구 API 추가

### DIFF
--- a/src/docs/asciidoc/follow.adoc
+++ b/src/docs/asciidoc/follow.adoc
@@ -93,24 +93,48 @@ operation::follow-controller-test/get-follower-slice-fail-invalid-token[snippets
 
 === *6-1 성공*
 
-operation::follow-controller-test/search-followings-success[snippets='http-request,request-headers,http-response']
+operation::follow-controller-test/search-followings-success[snippets='http-request,request-headers,query-parameters,http-response']
 
 === *6-2 실패 - 닉네임이 없는 경우*
 
-operation::follow-controller-test/search-followings-fail-nickname-null[snippets='http-request,request-headers,http-response']
+operation::follow-controller-test/search-followings-fail-nickname-null[snippets='http-request,request-headers,query-parameters,http-response']
 
 === *6-3 실패 - 유효하지 않은 마지막 id*
 
-operation::follow-controller-test/search-followings-fail-invalid-last-id[snippets='http-request,request-headers,http-response']
+operation::follow-controller-test/search-followings-fail-invalid-last-id[snippets='http-request,request-headers,query-parameters,http-response']
 
 === *6-4 실패 - 유효하지 않은 사이즈*
 
-operation::follow-controller-test/search-followings-fail-invalid-size[snippets='http-request,request-headers,http-response']
+operation::follow-controller-test/search-followings-fail-invalid-size[snippets='http-request,request-headers,query-parameters,http-response']
 
 === *6-5 실패 - 가입하지 않은 유저*
 
-operation::follow-controller-test/search-followings-fail-not-registered-user[snippets='http-request,request-headers,http-response']
+operation::follow-controller-test/search-followings-fail-not-registered-user[snippets='http-request,request-headers,query-parameters,http-response']
 
 === *6-5 실패 - 유효하지 않은 토큰*
 
-operation::follow-controller-test/search-followings-fail-invalid-token[snippets='http-request,request-headers,http-response']
+operation::follow-controller-test/search-followings-fail-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']
+
+
+[[알수도-있는-유저-검색-API]]
+== *7. 알수도 있는 유저 검색 API*
+
+=== *7-1 성공*
+
+operation::follow-controller-test/get-may-know-success[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *7-2 실패 - 유효하지 않은 마지막 id*
+
+operation::follow-controller-test/get-may-know-fail-invalid-last-id[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *7-3 실패 - 유효하지 않은 사이즈*
+
+operation::follow-controller-test/get-may-know-fail-invalid-size[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *7-4 실패 - 가입하지 않은 유저*
+
+operation::follow-controller-test/get-may-know-fail-not-registered-user[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *7-5 실패 - 유효하지 않은 토큰*
+
+operation::follow-controller-test/get-may-know-fail-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']

--- a/src/main/kotlin/kr/weit/odya/controller/FollowController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/FollowController.kt
@@ -96,4 +96,17 @@ class FollowController(
     ): ResponseEntity<SliceResponse<FollowUserResponse>> {
         return ResponseEntity.ok(followService.searchByNickname(userId, nickname, size, lastId))
     }
+
+    @GetMapping("/may-know") // 페이스 북에서는 알수도 있는 친구를 you may know라고 표현하길래 따라해봤습니다
+    fun getMayKnowFollowings(
+        @LoginUserId userId: Long,
+        @Positive(message = "사이즈는 양수여야 합니다.")
+        @RequestParam(name = "size", required = false, defaultValue = "10")
+        size: Int,
+        @Positive(message = "마지막 Id는 양수여야 합니다.")
+        @RequestParam(name = "lastId", required = false)
+        lastId: Long?,
+    ): ResponseEntity<SliceResponse<FollowUserResponse>> {
+        return ResponseEntity.ok(followService.getMayKnowFollowings(userId, size, lastId))
+    }
 }

--- a/src/main/kotlin/kr/weit/odya/domain/follow/FollowRepository.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/follow/FollowRepository.kt
@@ -31,6 +31,13 @@ fun FollowRepository.getByFollowerIdAndFollowingIdIn(
 ): List<Follow> =
     findAllByFollowerIdAndFollowingIdInAndLastId(follower, followingIds, size, lastId)
 
+fun FollowRepository.getMayKnowFollowings(
+    followerId: Long,
+    size: Int,
+    lastId: Long?,
+): List<Follow> =
+    findMayKnowFollowings(followerId, size, lastId)
+
 interface FollowRepository : JpaRepository<Follow, Long>, CustomFollowRepository {
     fun existsByFollowerIdAndFollowingId(followerId: Long, followingId: Long): Boolean
 
@@ -59,8 +66,14 @@ interface CustomFollowRepository {
     ): List<Follow>
 
     fun findAllByFollowerIdAndFollowingIdInAndLastId(
-        follower: Long,
+        followerId: Long,
         followingIds: List<Long>,
+        size: Int,
+        lastId: Long?,
+    ): List<Follow>
+
+    fun findMayKnowFollowings(
+        followerId: Long,
         size: Int,
         lastId: Long?,
     ): List<Follow>
@@ -96,7 +109,7 @@ class FollowRepositoryImpl(private val queryFactory: QueryFactory) : CustomFollo
     }
 
     override fun findAllByFollowerIdAndFollowingIdInAndLastId(
-        follower: Long,
+        followerId: Long,
         followingIds: List<Long>,
         size: Int,
         lastId: Long?,
@@ -107,12 +120,46 @@ class FollowRepositoryImpl(private val queryFactory: QueryFactory) : CustomFollo
         from(entity(Follow::class))
         associate(Follow::class, followerUser, on(Follow::follower))
         associate(Follow::class, followingUser, on(Follow::following))
-        where(col(followerUser, User::id).equal(follower))
-        where(col(followingUser, User::id).`in`(followingIds))
+        where(
+            and(
+                col(followerUser, User::id).equal(followerId),
+                col(followingUser, User::id).`in`(followingIds),
+            ),
+        )
         if (lastId != null) {
             where(col(followingUser, User::id).lessThan(lastId))
         }
         limit(size)
+    }
+
+    override fun findMayKnowFollowings(
+        followerId: Long,
+        size: Int,
+        lastId: Long?,
+    ): List<Follow> {
+        val followingList = queryFactory.listQuery<User> {
+            select(column(entity(Follow::class), Follow::following))
+            from(entity(Follow::class))
+            associate(entity(Follow::class), entity(User::class), on(Follow::follower))
+            where(col(entity(User::class), User::id).equal(followerId))
+        }
+
+        return queryFactory.listQuery {
+            select(entity(Follow::class))
+            from(entity(Follow::class))
+            associate(Follow::class, entity(User::class), on(Follow::following))
+            where(
+                and(
+                    col(entity(User::class), User::id).notEqual(followerId),
+                    col(entity(Follow::class), Follow::follower).`in`(followingList),
+                    not(col(entity(Follow::class), Follow::following).`in`(followingList)),
+                ),
+            )
+            if (lastId != null) {
+                where(col(entity(User::class), User::id).lessThan(lastId))
+            }
+            limit(size)
+        }
     }
 
     private fun <T> CriteriaQueryDsl<T>.dynamicOrderingByFollowSortType(

--- a/src/main/kotlin/kr/weit/odya/service/FollowService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/FollowService.kt
@@ -6,6 +6,7 @@ import kr.weit.odya.domain.follow.FollowSortType
 import kr.weit.odya.domain.follow.getByFollowerIdAndFollowingIdIn
 import kr.weit.odya.domain.follow.getFollowerListBySearchCond
 import kr.weit.odya.domain.follow.getFollowingListBySearchCond
+import kr.weit.odya.domain.follow.getMayKnowFollowings
 import kr.weit.odya.domain.user.UserRepository
 import kr.weit.odya.domain.user.UsersDocumentRepository
 import kr.weit.odya.domain.user.getByNickname
@@ -91,5 +92,20 @@ class FollowService(
                 )
             }
         return SliceResponse(size, followings)
+    }
+
+    @Transactional(readOnly = true)
+    fun getMayKnowFollowings(userId: Long, size: Int, lastId: Long?): SliceResponse<FollowUserResponse> {
+        val mayKnowFollowings = followRepository.getMayKnowFollowings(userId, size + 1, lastId)
+
+        return SliceResponse(
+            size,
+            mayKnowFollowings.map {
+                FollowUserResponse(
+                    it.following,
+                    fileService.getPreAuthenticatedObjectUrl(it.following.profile.profileName),
+                )
+            },
+        )
     }
 }

--- a/src/test/kotlin/kr/weit/odya/controller/FollowControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/FollowControllerTest.kt
@@ -693,6 +693,11 @@ class FollowControllerTest(
                             requestHeaders(
                                 HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                             ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example "null" isOptional true,
+                                LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example "null" isOptional true,
+                                NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
+                            ),
                         )
                     }
                 }
@@ -712,6 +717,142 @@ class FollowControllerTest(
                             "search-followings-fail-invalid-token",
                             requestHeaders(
                                 HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example "null" isOptional true,
+                                LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example "null" isOptional true,
+                                NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+
+        describe("GET /api/v1/follows/may-know") {
+            val targetUri = "/api/v1/follows/may-know"
+            context("유효한 토큰이면서, 가입된 사용자인 경우") {
+                val response = createFollowSlice()
+                every { followService.getMayKnowFollowings(TEST_USER_ID, TEST_SIZE, TEST_LAST_ID) } returns response
+                it("200 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(SIZE_PARAM, TEST_SIZE.toString())
+                        param(LAST_ID_PARAM, TEST_LAST_ID.toString())
+                    }.andExpect {
+                        status { isOk() }
+                    }.andDo {
+                        val content = response.content[0]
+                        createDocument(
+                            "get-may-know-success",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example "null" isOptional true,
+                                LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example "null" isOptional true,
+                            ),
+                            responseBody(
+                                "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
+                                "content[].userId" type JsonFieldType.NUMBER description "사용자 ID" example content.userId,
+                                "content[].nickname" type JsonFieldType.STRING description "사용자 닉네임" example content.nickname,
+                                "content[].profile.profileUrl" type JsonFieldType.STRING description "사용자 프로필 Url" example content.profile.profileUrl,
+                                "content[].profile.profileColor.colorHex" type JsonFieldType.STRING description "색상 Hex" example content.profile.profileColor?.colorHex isOptional true,
+                                "content[].profile.profileColor.red" type JsonFieldType.NUMBER description "RGB RED" example content.profile.profileColor?.red isOptional true,
+                                "content[].profile.profileColor.green" type JsonFieldType.NUMBER description "RGB GREEN" example content.profile.profileColor?.green isOptional true,
+                                "content[].profile.profileColor.blue" type JsonFieldType.NUMBER description "RGB BLUE" example content.profile.profileColor?.blue isOptional true,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효한 토큰이지만 조회할 마지막 ID가 양수가 아닌 경우") {
+                it("400 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(SIZE_PARAM, TEST_SIZE.toString())
+                        param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString())
+                    }.andExpect {
+                        status { isBadRequest() }
+                    }.andDo {
+                        createDocument(
+                            "get-may-know-fail-invalid-last-id",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                LAST_ID_PARAM parameterDescription "양수가 아닌 마지막 데이터의 ID" example TEST_INVALID_LAST_ID isOptional true,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효한 토큰이지만 size가 양수가 아닌 경우") {
+                it("400 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
+                        param(LAST_ID_PARAM, TEST_LAST_ID.toString())
+                    }.andExpect {
+                        status { isBadRequest() }
+                    }.andDo {
+                        createDocument(
+                            "get-may-know-fail-invalid-size",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "양수가 아닌 데이터 개수" example TEST_INVALID_SIZE isOptional true,
+                                LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효한 토큰이면서, 가입되지 않은 사용자인 경우") {
+                it("401 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN)
+                        param(SIZE_PARAM, TEST_SIZE.toString())
+                        param(LAST_ID_PARAM, TEST_LAST_ID.toString())
+                    }.andExpect {
+                        status { isUnauthorized() }
+                    }.andDo {
+                        createDocument(
+                            "get-may-know-fail-not-registered-user",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example "null" isOptional true,
+                                LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example "null" isOptional true,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효하지 않은 토큰이면") {
+                it("401 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                        param(SIZE_PARAM, TEST_SIZE.toString())
+                        param(LAST_ID_PARAM, TEST_LAST_ID.toString())
+                    }.andExpect {
+                        status { isUnauthorized() }
+                    }.andDo {
+                        createDocument(
+                            "get-may-know-fail-invalid-token",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example "null" isOptional true,
+                                LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example "null" isOptional true,
                             ),
                         )
                     }

--- a/src/test/kotlin/kr/weit/odya/domain/follow/FollowRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/odya/domain/follow/FollowRepositoryTest.kt
@@ -7,9 +7,9 @@ import kr.weit.odya.domain.user.UserRepository
 import kr.weit.odya.support.TEST_DEFAULT_PAGEABLE
 import kr.weit.odya.support.TEST_DEFAULT_SIZE
 import kr.weit.odya.support.TEST_DEFAULT_SORT_TYPE
+import kr.weit.odya.support.createAnotherUser
 import kr.weit.odya.support.createFollow
 import kr.weit.odya.support.createOtherUser
-import kr.weit.odya.support.createTheAnotherUser
 import kr.weit.odya.support.createUser
 import kr.weit.odya.support.test.BaseTests.RepositoryTest
 
@@ -21,7 +21,7 @@ class FollowRepositoryTest(
     {
         val follower: User = userRepository.save(createUser())
         val following: User = userRepository.save(createOtherUser())
-        val notFollowing: User = userRepository.save(createTheAnotherUser())
+        val notFollowing: User = userRepository.save(createAnotherUser())
         beforeEach {
             followRepository.save(createFollow(follower, following))
             followRepository.save(createFollow(following, follower))

--- a/src/test/kotlin/kr/weit/odya/domain/follow/FollowRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/odya/domain/follow/FollowRepositoryTest.kt
@@ -9,6 +9,7 @@ import kr.weit.odya.support.TEST_DEFAULT_SIZE
 import kr.weit.odya.support.TEST_DEFAULT_SORT_TYPE
 import kr.weit.odya.support.createFollow
 import kr.weit.odya.support.createOtherUser
+import kr.weit.odya.support.createTheAnotherUser
 import kr.weit.odya.support.createUser
 import kr.weit.odya.support.test.BaseTests.RepositoryTest
 
@@ -20,9 +21,11 @@ class FollowRepositoryTest(
     {
         val follower: User = userRepository.save(createUser())
         val following: User = userRepository.save(createOtherUser())
+        val notFollowing: User = userRepository.save(createTheAnotherUser())
         beforeEach {
             followRepository.save(createFollow(follower, following))
             followRepository.save(createFollow(following, follower))
+            followRepository.save(createFollow(following, notFollowing))
         }
 
         context("팔로우 목록 조회") {
@@ -118,6 +121,33 @@ class FollowRepositoryTest(
                     userIds,
                     TEST_DEFAULT_SIZE,
                     following.id,
+                )
+                result.size shouldBe 0
+            }
+        }
+
+        context("알수도 있는 유저 검색") {
+            expect("알수도 있는 유저를 조회한다") {
+                val result = followRepository.getMayKnowFollowings(
+                    follower.id,
+                    TEST_DEFAULT_SIZE,
+                    null,
+                )
+                result.size shouldBe 1
+            }
+
+            expect("lastId보다 작은 알수도 있는 유저를 조회한다") {
+                var result = followRepository.getMayKnowFollowings(
+                    follower.id,
+                    TEST_DEFAULT_SIZE,
+                    notFollowing.id + 1,
+                )
+                result.size shouldBe 1
+
+                result = followRepository.getMayKnowFollowings(
+                    follower.id,
+                    TEST_DEFAULT_SIZE,
+                    notFollowing.id,
                 )
                 result.size shouldBe 0
             }

--- a/src/test/kotlin/kr/weit/odya/service/FollowServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/FollowServiceTest.kt
@@ -12,6 +12,7 @@ import kr.weit.odya.domain.follow.FollowRepository
 import kr.weit.odya.domain.follow.getByFollowerIdAndFollowingIdIn
 import kr.weit.odya.domain.follow.getFollowerListBySearchCond
 import kr.weit.odya.domain.follow.getFollowingListBySearchCond
+import kr.weit.odya.domain.follow.getMayKnowFollowings
 import kr.weit.odya.domain.user.UserRepository
 import kr.weit.odya.domain.user.UsersDocumentRepository
 import kr.weit.odya.domain.user.getByNickname
@@ -203,6 +204,17 @@ class FollowServiceTest : DescribeSpec(
                 every { fileService.getPreAuthenticatedObjectUrl(TEST_DEFAULT_PROFILE_PNG) } returns TEST_PROFILE_URL
                 it("유저를 조회 한다") {
                     shouldNotThrowAny { followService.searchByNickname(TEST_USER_ID, TEST_NICKNAME, 10, null) }
+                }
+            }
+        }
+
+        describe("getMayKnowFollowings") {
+            context("요청이 들어오면") {
+                val user = createUser()
+                every { followRepository.getMayKnowFollowings(any(), any(), any()) } returns createFollowList()
+                every { fileService.getPreAuthenticatedObjectUrl(TEST_DEFAULT_PROFILE_PNG) } returns TEST_PROFILE_URL
+                it("알수도 있는 유저를 조회 한다") {
+                    shouldNotThrowAny { followService.getMayKnowFollowings(TEST_USER_ID, 10, null) }
                 }
             }
         }

--- a/src/test/kotlin/kr/weit/odya/support/UserFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/UserFixtures.kt
@@ -14,22 +14,22 @@ import java.time.LocalDate
 
 const val TEST_USER_ID = 1L
 const val TEST_OTHER_USER_ID = 2L
-const val TEST_THE_ANOTHER_USER_ID = 3L
+const val TEST_ANOTHER_USER_ID = 3L
 const val TEST_NOT_EXIST_USER_ID = 4L
 const val TEST_INVALID_USER_ID = -1L
 const val TEST_USERNAME = "testUsername"
 const val TEST_OTHER_USERNAME = "testOtherUsername"
-const val TEST_THE_ANOTHER_USERNAME = "testTheOtherUsername"
+const val TEST_ANOTHER_USERNAME = "testAnotherUsername"
 const val TEST_EMAIL = "test@test.com"
 const val TEST_OTHER_EMAIL = "other@test.com"
-const val TEST_THE_ANOTHER_EMAIL = "the_other@test.com"
+const val TEST_ANOTHER_EMAIL = "another@test.com"
 const val TEST_INVALID_EMAIL = "test"
 const val TEST_NICKNAME = "testNickname"
 const val TEST_OTHER_NICKNAME = "testOtherNickname"
-const val TEST_THE_ANOTHER_NICKNAME = "testTheOtherNickname"
+const val TEST_ANOTHER_NICKNAME = "testAnotherNickname"
 const val TEST_PHONE_NUMBER = "010-1234-1234"
 const val TEST_OTHER_PHONE_NUMBER = "010-1234-1235"
-const val TEST_THE_ANOTHER_PHONE_NUMBER = "010-1234-1236"
+const val TEST_ANOTHER_PHONE_NUMBER = "010-1234-1236"
 const val TEST_INVALID_PHONE_NUMBER = "01012341234"
 const val TEST_PROFILE_ID = 1L
 val TEST_GENDER: Gender = Gender.M
@@ -62,12 +62,12 @@ fun createOtherUser(): User = User(
     profile = createProfile(TEST_PROFILE_ID),
 )
 
-fun createTheAnotherUser(): User = User(
-    id = TEST_THE_ANOTHER_USER_ID,
-    username = TEST_THE_ANOTHER_USERNAME,
-    email = TEST_THE_ANOTHER_EMAIL,
-    nickname = TEST_THE_ANOTHER_NICKNAME,
-    phoneNumber = TEST_THE_ANOTHER_PHONE_NUMBER,
+fun createAnotherUser(): User = User(
+    id = TEST_ANOTHER_USER_ID,
+    username = TEST_ANOTHER_USERNAME,
+    email = TEST_ANOTHER_EMAIL,
+    nickname = TEST_ANOTHER_NICKNAME,
+    phoneNumber = TEST_ANOTHER_PHONE_NUMBER,
     gender = TEST_GENDER,
     birthday = TEST_BIRTHDAY,
     socialType = TEST_SOCIAL_TYPE,

--- a/src/test/kotlin/kr/weit/odya/support/UserFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/UserFixtures.kt
@@ -13,24 +13,29 @@ import kr.weit.odya.service.dto.UserSimpleResponse
 import java.time.LocalDate
 
 const val TEST_USER_ID = 1L
+const val TEST_OTHER_USER_ID = 2L
+const val TEST_THE_ANOTHER_USER_ID = 3L
+const val TEST_NOT_EXIST_USER_ID = 4L
 const val TEST_INVALID_USER_ID = -1L
-const val TEST_NOT_EXIST_USER_ID = 2L
 const val TEST_USERNAME = "testUsername"
 const val TEST_OTHER_USERNAME = "testOtherUsername"
+const val TEST_THE_ANOTHER_USERNAME = "testTheOtherUsername"
 const val TEST_EMAIL = "test@test.com"
 const val TEST_OTHER_EMAIL = "other@test.com"
+const val TEST_THE_ANOTHER_EMAIL = "the_other@test.com"
 const val TEST_INVALID_EMAIL = "test"
 const val TEST_NICKNAME = "testNickname"
 const val TEST_OTHER_NICKNAME = "testOtherNickname"
+const val TEST_THE_ANOTHER_NICKNAME = "testTheOtherNickname"
 const val TEST_PHONE_NUMBER = "010-1234-1234"
 const val TEST_OTHER_PHONE_NUMBER = "010-1234-1235"
+const val TEST_THE_ANOTHER_PHONE_NUMBER = "010-1234-1236"
 const val TEST_INVALID_PHONE_NUMBER = "01012341234"
 const val TEST_PROFILE_ID = 1L
 val TEST_GENDER: Gender = Gender.M
 val TEST_BIRTHDAY: LocalDate = LocalDate.of(1999, 10, 10)
 val TEST_SOCIAL_TYPE: SocialType = SocialType.KAKAO
 val TEST_USER_ROLE = UserRole.ROLE_USER
-const val TEST_OTHER_USER_ID = 2L
 val TEST_USER = createUser()
 
 fun createUser(profileName: String = TEST_DEFAULT_PROFILE_PNG): User = User(
@@ -51,6 +56,18 @@ fun createOtherUser(): User = User(
     email = TEST_OTHER_EMAIL,
     nickname = TEST_OTHER_NICKNAME,
     phoneNumber = TEST_OTHER_PHONE_NUMBER,
+    gender = TEST_GENDER,
+    birthday = TEST_BIRTHDAY,
+    socialType = TEST_SOCIAL_TYPE,
+    profile = createProfile(TEST_PROFILE_ID),
+)
+
+fun createTheAnotherUser(): User = User(
+    id = TEST_THE_ANOTHER_USER_ID,
+    username = TEST_THE_ANOTHER_USERNAME,
+    email = TEST_THE_ANOTHER_EMAIL,
+    nickname = TEST_THE_ANOTHER_NICKNAME,
+    phoneNumber = TEST_THE_ANOTHER_PHONE_NUMBER,
     gender = TEST_GENDER,
     birthday = TEST_BIRTHDAY,
     socialType = TEST_SOCIAL_TYPE,


### PR DESCRIPTION
### 개요
- 알수도 있는 친구를 조회하는 API가 필요하다
- 알수도 있는 친구란 내가 팔로잉 하는 유저가 팔로잉하는 유저중에 내가 팔로잉 하지 않은 유저를 의미한다
- ex) 김한빈이 김채린을, 김채린이 최영찬을 요렇게 팔로우 하는 상황에서 최영찬은 김한빈의 알 수도 있는 친구가 된다

### 변경사항
- 알 수도 있는 친구 조회 API 추가
- 이전에 반영되지 않은 리뷰사항 반영

### 관련 지라 및 위키 링크
- [ODYA-127](https://weit.atlassian.net/browse/ODYA-127)

### 리뷰어에게 하고 싶은 말
- 어... 이게 만드는게 맞나 싶긴 할정도로 끔찍한 쿼리네요 ㅋㅋㅋ...
- 그리고 무거운 쿼리인 만큼 클라 분들이 자주 찌르지 않도록 가이드를 드릴 예정입니다.
