### PR TITLE
ODYA-136 깨지는 테스트 수정

### DIFF
--- a/src/test/kotlin/kr/weit/odya/domain/traveljournal/TravelJournalRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/odya/domain/traveljournal/TravelJournalRepositoryTest.kt
@@ -5,8 +5,8 @@ import io.kotest.matchers.shouldBe
 import kr.weit.odya.domain.contentimage.ContentImageRepository
 import kr.weit.odya.domain.user.User
 import kr.weit.odya.domain.user.UserRepository
-import kr.weit.odya.support.TEST_USER_ID
 import kr.weit.odya.support.TEST_TRAVEL_JOURNAL_ID
+import kr.weit.odya.support.TEST_USER_ID
 import kr.weit.odya.support.createContentImage
 import kr.weit.odya.support.createOtherUser
 import kr.weit.odya.support.createTravelCompanionById
@@ -42,17 +42,18 @@ class TravelJournalRepositoryTest(
                 ),
             )
         }
-        context("여행일지 사용자 Id로 조회") {
-            expect("유저 ID와 일치하는 여행기록을 조회한다.") {
-                val result = travelJournalRepository.getByUserId(TEST_USER_ID)
-                result.size shouldBe 1
-            }
-        }
 
         context("여행 일지 조회") {
             expect("여행 일지 ID와 일치하는 여행 일지를 조회한다.") {
                 val result = travelJournalRepository.getByTravelJournalId(TEST_TRAVEL_JOURNAL_ID)
                 result.id shouldBe TEST_TRAVEL_JOURNAL_ID
+            }
+        }
+
+        context("여행일지 사용자 Id로 조회") {
+            expect("유저 ID와 일치하는 여행기록을 조회한다.") {
+                val result = travelJournalRepository.getByUserId(TEST_USER_ID)
+                result.size shouldBe 1
             }
         }
     },


### PR DESCRIPTION
### 개요
- 테스트가 깨진다

### 변경사항
- 테스트가 실행되는 순서 차이로 깨지는데 일단 문제가 없도록 처리

### 관련 지라 및 위키 링크
- [ODYA-136](https://weit.atlassian.net/browse/ODYA-136)

### 리뷰어에게 하고 싶은 말
- 순서 차이로 에러가 발생하는건 아마 id가 시퀀스로 증가하니까 그러는것 같은데
- 앞으로는 테스트 코드에서 id 비교 하는건 지양해야 할것 같네요 ㅋㅋㅋㅋ...
