### PR TITLE
ODYA-152 메인 뷰 좌표 조회 API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("com.h2database:h2:2.2.222")
+    testImplementation("org.orbisgis:h2gis:2.2.0")
 
     testImplementation("io.mockk:mockk:1.13.5")
     testImplementation("com.ninja-squad:springmockk:4.0.2")

--- a/src/docs/asciidoc/image.adoc
+++ b/src/docs/asciidoc/image.adoc
@@ -1,3 +1,6 @@
+[[Image-API]]
+= *Image API*
+
 [[유저-사진-조회-API]]
 == *1. 유저 사진 조회 API*
 

--- a/src/docs/asciidoc/image.adoc
+++ b/src/docs/asciidoc/image.adoc
@@ -86,7 +86,7 @@ operation::image-controller-test/unset-life-shot-fail-invalid-token[snippets='ht
 | `USER`
 | 요청한 사용자 본인의 사진
 
-| `FIEND`
+| `FRIEND`
 | 요청한 사용자의 친구의 사진
 
 | `OTHER`

--- a/src/docs/asciidoc/image.adoc
+++ b/src/docs/asciidoc/image.adoc
@@ -70,3 +70,54 @@ operation::image-controller-test/unset-life-shot-fail-not-registered-user[snippe
 === *3-4 실패 - 유효하지 않은 토큰*
 
 operation::image-controller-test/unset-life-shot-fail-invalid-token[snippets='http-request,request-headers,path-parameters,request-body,http-response']
+
+[[좌표-사진-조회-API]]
+
+== *4. 좌표 사진 조회 API*
+
+== *ImageUserType*
+
+|===
+| type | description
+
+| `USER`
+| 요청한 사용자 본인의 사진
+
+| `FIEND`
+| 요청한 사용자의 친구의 사진
+
+| `OTHER`
+| 요청한 사용자의 친구가 아닌 사진
+|===
+
+=== *4-1 성공*
+
+operation::image-controller-test/get-coordinate-images-success[snippets='http-request,query-parameters,request-headers,http-response']
+
+=== *4-2 실패 - 유효하지 않은 사이즈*
+
+operation::image-controller-test/get-coordinate-images-fail-invalid-size[snippets='http-request,query-parameters,request-headers,http-response']
+
+=== *4-3 실패 - 유효하지 않은 좌측 경도*
+
+operation::image-controller-test/get-coordinate-images-fail-invalid-left-longitude[snippets='http-request,query-parameters,request-headers,http-response']
+
+=== *4-4 실패 - 유효하지 않은 하단 위도*
+
+operation::image-controller-test/get-coordinate-images-fail-invalid-bottom-latitude[snippets='http-request,query-parameters,request-headers,http-response']
+
+=== *4-5 실패 - 유효하지 않은 우측 경도*
+
+operation::image-controller-test/get-coordinate-images-fail-invalid-right-longitude[snippets='http-request,query-parameters,request-headers,http-response']
+
+=== *4-6 실패 - 유효하지 않은 상단 위도*
+
+operation::image-controller-test/get-coordinate-images-fail-invalid-top-latitude[snippets='http-request,query-parameters,request-headers,http-response']
+
+=== *4-7 실패 - 가입되지 않은 유저*
+
+operation::image-controller-test/get-images-fail-not-registered-user[snippets='http-request,request-headers,http-response']
+
+=== *4-8 실패 - 유효하지 않은 토큰*
+
+operation::image-controller-test/get-images-fail-invalid-token[snippets='http-request,request-headers,http-response']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -25,4 +25,4 @@ include::terms.adoc[]
 include::community.adoc[]
 include::communityComment.adoc[]
 include::report.adoc[]
-include::image.adoc
+include::image.adoc[]

--- a/src/main/kotlin/kr/weit/odya/controller/ImageController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/ImageController.kt
@@ -4,12 +4,11 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive
 import kr.weit.odya.security.LoginUserId
 import kr.weit.odya.service.ImageService
+import kr.weit.odya.service.dto.CoordinateImageRequest
 import kr.weit.odya.service.dto.CoordinateImageResponse
 import kr.weit.odya.service.dto.ImageResponse
 import kr.weit.odya.service.dto.LifeShotRequest
 import kr.weit.odya.service.dto.SliceResponse
-import kr.weit.odya.support.validator.Latitude
-import kr.weit.odya.support.validator.Longitude
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -69,24 +68,13 @@ class ImageController(
         return ResponseEntity.noContent().build()
     }
 
-    @GetMapping("/map")
+    @GetMapping("/coordinate")
     fun getCoordinateImages(
-        @Longitude
-        @RequestParam
-        leftLongitude: Double,
-        @Latitude
-        @RequestParam
-        bottomLatitude: Double,
-        @Longitude
-        @RequestParam
-        rightLongitude: Double,
-        @Latitude
-        @RequestParam
-        topLatitude: Double,
-        @Positive(message = "사이즈는 양수여야 합니다.")
-        @RequestParam(name = "size", required = false, defaultValue = "100")
-        size: Int,
+        @LoginUserId
+        userId: Long,
+        @Valid
+        coordinateImageRequest: CoordinateImageRequest,
     ): ResponseEntity<List<CoordinateImageResponse>> {
-        return ResponseEntity.ok(imageService.getImagesWithCoordinate(leftLongitude, bottomLatitude, rightLongitude, topLatitude, size))
+        return ResponseEntity.ok(imageService.getImagesWithCoordinate(userId, coordinateImageRequest))
     }
 }

--- a/src/main/kotlin/kr/weit/odya/controller/ImageController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/ImageController.kt
@@ -4,9 +4,12 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive
 import kr.weit.odya.security.LoginUserId
 import kr.weit.odya.service.ImageService
+import kr.weit.odya.service.dto.CoordinateImageResponse
 import kr.weit.odya.service.dto.ImageResponse
 import kr.weit.odya.service.dto.LifeShotRequest
 import kr.weit.odya.service.dto.SliceResponse
+import kr.weit.odya.support.validator.Latitude
+import kr.weit.odya.support.validator.Longitude
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -64,5 +67,26 @@ class ImageController(
     ): ResponseEntity<Void> {
         imageService.cancelLifeShot(userId, imageId)
         return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/map")
+    fun getCoordinateImages(
+        @Longitude
+        @RequestParam
+        leftLongitude: Double,
+        @Latitude
+        @RequestParam
+        bottomLatitude: Double,
+        @Longitude
+        @RequestParam
+        rightLongitude: Double,
+        @Latitude
+        @RequestParam
+        topLatitude: Double,
+        @Positive(message = "사이즈는 양수여야 합니다.")
+        @RequestParam(name = "size", required = false, defaultValue = "100")
+        size: Int,
+    ): ResponseEntity<List<CoordinateImageResponse>> {
+        return ResponseEntity.ok(imageService.getImagesWithCoordinate(leftLongitude, bottomLatitude, rightLongitude, topLatitude, size))
     }
 }

--- a/src/main/kotlin/kr/weit/odya/domain/contentimage/ContentImageRepository.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/contentimage/ContentImageRepository.kt
@@ -17,6 +17,14 @@ fun ContentImageRepository.getLifeShotByUserId(userId: Long, size: Int, lastId: 
 
 fun ContentImageRepository.getImageById(id: Long) = findByIdOrNull(id) ?: throw NoSuchElementException("사진이 존재하지 않습니다.")
 
+fun ContentImageRepository.getImageByRectangle(
+    leftLongitude: Double,
+    bottomLatitude: Double,
+    rightLongitude: Double,
+    topLatitude: Double,
+    size: Int,
+) = findImagesByRectangleAndSize(leftLongitude, bottomLatitude, rightLongitude, topLatitude, size)
+
 interface ContentImageRepository : JpaRepository<ContentImage, Long>, CustomContentImageRepository {
     fun findAllByUserId(userId: Long): List<ContentImage>
 
@@ -26,6 +34,14 @@ interface ContentImageRepository : JpaRepository<ContentImage, Long>, CustomCont
 interface CustomContentImageRepository {
     fun findSliceByUserId(userId: Long, size: Int, lastId: Long?): List<ContentImage>
     fun findLifeShotSliceByUserId(userId: Long, size: Int, lastId: Long?): List<ContentImage>
+
+    fun findImagesByRectangleAndSize(
+        leftLongitude: Double,
+        bottomLatitude: Double,
+        rightLongitude: Double,
+        topLatitude: Double,
+        size: Int,
+    ): List<ContentImage>
 }
 
 class CustomContentImageRepositoryImpl(private val queryFactory: QueryFactory) : CustomContentImageRepository {
@@ -38,6 +54,39 @@ class CustomContentImageRepositoryImpl(private val queryFactory: QueryFactory) :
         queryFactory.listQuery {
             getImagesSliceBaseQuery(userId, size, lastId)
             where(col(ContentImage::isLifeShot).equal(true))
+        }
+
+    override fun findImagesByRectangleAndSize(
+        leftLongitude: Double,
+        bottomLatitude: Double,
+        rightLongitude: Double,
+        topLatitude: Double,
+        size: Int,
+    ): List<ContentImage> =
+        queryFactory.listQuery {
+            select(entity(ContentImage::class))
+            from(entity(ContentImage::class))
+            where(
+                and(
+                    col(ContentImage::coordinate).isNotNull(),
+                    function(
+                        "within",
+                        Boolean::class.java,
+                        function(
+                            "rectangle",
+                            Any::class.java, // 원래는 Geometry::class.java로 해야 하지만, jdsl인지 hibernate인지 둘중 하나가 에러를 발생시키므로 Any::class.java로 한다
+                            literal(leftLongitude),
+                            literal(bottomLatitude),
+                            literal(rightLongitude),
+                            literal(topLatitude),
+                            literal(ContentImage.SRID_WGS84),
+                        ),
+                        col(ContentImage::coordinate),
+                    ).equal(true),
+                ),
+            )
+            orderBy(col(ContentImage::id).desc())
+            limit(size)
         }
 
     private fun CriteriaQueryDsl<ContentImage>.getImagesSliceBaseQuery(userId: Long, size: Int, lastId: Long?) {

--- a/src/main/kotlin/kr/weit/odya/domain/follow/FollowRepository.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/follow/FollowRepository.kt
@@ -12,6 +12,7 @@ import kr.weit.odya.domain.traveljournal.TravelJournalContent
 import kr.weit.odya.domain.user.User
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.transaction.annotation.Transactional
 
 fun FollowRepository.getFollowingListBySearchCond(
@@ -49,6 +50,9 @@ fun FollowRepository.getFollowerFcmTokens(followingId: Long): List<String> =
 fun FollowRepository.getVisitedFollowingIds(placeID: String, followerId: Long): List<Long> =
     findVisitedFollowingIdsByPlaceIdAndFollowerId(placeID, followerId)
 
+fun FollowRepository.getFollowingIds(followerId: Long): List<Long> =
+    findFollowingIdsByFollowerId(followerId)
+
 interface FollowRepository : JpaRepository<Follow, Long>, CustomFollowRepository {
     fun existsByFollowerIdAndFollowingId(followerId: Long, followingId: Long): Boolean
 
@@ -61,6 +65,9 @@ interface FollowRepository : JpaRepository<Follow, Long>, CustomFollowRepository
     fun deleteByFollowingId(followingId: Long)
 
     fun deleteByFollowerId(follower: Long)
+
+    @Query("select f.following.id from Follow f where f.follower.id = :followerId")
+    fun findFollowingIdsByFollowerId(followerId: Long): List<Long>
 }
 
 interface CustomFollowRepository {

--- a/src/main/kotlin/kr/weit/odya/service/ImageService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/ImageService.kt
@@ -3,8 +3,10 @@ package kr.weit.odya.service
 import jakarta.ws.rs.ForbiddenException
 import kr.weit.odya.domain.contentimage.ContentImageRepository
 import kr.weit.odya.domain.contentimage.getImageById
+import kr.weit.odya.domain.contentimage.getImageByRectangle
 import kr.weit.odya.domain.contentimage.getImageByUserId
 import kr.weit.odya.domain.contentimage.getLifeShotByUserId
+import kr.weit.odya.service.dto.CoordinateImageResponse
 import kr.weit.odya.service.dto.ImageResponse
 import kr.weit.odya.service.dto.LifeShotRequest
 import kr.weit.odya.service.dto.SliceResponse
@@ -20,13 +22,19 @@ class ImageService(
     @Transactional(readOnly = true)
     fun getImages(userId: Long, size: Int, lastId: Long?): SliceResponse<ImageResponse> {
         val images = contentImageRepository.getImageByUserId(userId, size, lastId)
-        return SliceResponse(size, images.map { ImageResponse.of(it, fileService.getPreAuthenticatedObjectUrl(it.name)) })
+        return SliceResponse(
+            size,
+            images.map { ImageResponse.of(it, fileService.getPreAuthenticatedObjectUrl(it.name)) },
+        )
     }
 
     @Transactional(readOnly = true)
     fun getLifeShots(userId: Long, size: Int, lastId: Long?): SliceResponse<ImageResponse> {
         val images = contentImageRepository.getLifeShotByUserId(userId, size, lastId)
-        return SliceResponse(size, images.map { ImageResponse.of(it, fileService.getPreAuthenticatedObjectUrl(it.name)) })
+        return SliceResponse(
+            size,
+            images.map { ImageResponse.of(it, fileService.getPreAuthenticatedObjectUrl(it.name)) },
+        )
     }
 
     @Transactional
@@ -46,5 +54,17 @@ class ImageService(
         }
         // 인생샷이 아닌 사진을 취소해도 에러를 발생시키지 않도록 한다
         image.unsetLifeShot()
+    }
+
+    @Transactional(readOnly = true)
+    fun getImagesWithCoordinate(
+        leftLongitude: Double,
+        bottomLatitude: Double,
+        rightLongitude: Double,
+        topLatitude: Double,
+        size: Int,
+    ): List<CoordinateImageResponse> {
+        return contentImageRepository.getImageByRectangle(leftLongitude, bottomLatitude, rightLongitude, topLatitude, size)
+            .map { CoordinateImageResponse.of(it, fileService.getPreAuthenticatedObjectUrl(it.name)) }
     }
 }

--- a/src/main/kotlin/kr/weit/odya/service/ImageService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/ImageService.kt
@@ -67,14 +67,25 @@ class ImageService(
         coordinateImageRequest: CoordinateImageRequest,
     ): List<CoordinateImageResponse> {
         val friendIdList = followRepository.getFollowingIds(userId)
-        return contentImageRepository.getImageByRectangle(coordinateImageRequest)
-            .map { CoordinateImageResponse.of(it, getImageUserType(userId, it.user.id, friendIdList), fileService.getPreAuthenticatedObjectUrl(it.name)) }
+        return contentImageRepository.getImageByRectangle(
+            coordinateImageRequest.leftLongitude,
+            coordinateImageRequest.bottomLatitude,
+            coordinateImageRequest.rightLongitude,
+            coordinateImageRequest.topLatitude,
+            coordinateImageRequest.size,
+        ).map {
+            CoordinateImageResponse.of(
+                it,
+                getImageUserType(userId, it.user.id, friendIdList),
+                fileService.getPreAuthenticatedObjectUrl(it.name),
+            )
+        }
     }
 
     private fun getImageUserType(userId: Long, imageOwnerId: Long, friendIdList: List<Long>): ImageUserType {
         return when {
             userId == imageOwnerId -> ImageUserType.USER
-            friendIdList.contains(imageOwnerId) -> ImageUserType.FIEND
+            friendIdList.contains(imageOwnerId) -> ImageUserType.FRIEND
             else -> ImageUserType.OTHER
         }
     }

--- a/src/main/kotlin/kr/weit/odya/service/dto/ImageDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/service/dto/ImageDtos.kt
@@ -1,6 +1,9 @@
 package kr.weit.odya.service.dto
 
+import jakarta.validation.constraints.Positive
 import kr.weit.odya.domain.contentimage.ContentImage
+import kr.weit.odya.support.validator.Latitude
+import kr.weit.odya.support.validator.Longitude
 import kr.weit.odya.support.validator.NullOrNotBlank
 import org.hibernate.validator.constraints.Length
 
@@ -39,19 +42,40 @@ data class CoordinateImageResponse(
     val placeId: String,
     val latitude: Double,
     val longitude: Double,
+    val imageUserType: ImageUserType,
     val journalId: Long?,
     val communityId: Long?,
 ) {
     companion object {
-        fun of(image: ContentImage, url: String) = CoordinateImageResponse(
+        fun of(image: ContentImage, imageUserType: ImageUserType, url: String) = CoordinateImageResponse(
             image.id,
             image.user.id,
             url,
             image.placeId!!,
             image.coordinate!!.y,
             image.coordinate!!.x,
+            imageUserType,
             image.travelJournalContentImage?.id,
             image.communityContentImage?.id,
         )
     }
 }
+
+enum class ImageUserType {
+    USER, // 요청한 사용자 본인의 사진
+    FIEND, // 요청한 사용자의 친구의 사진
+    OTHER, // 요청한 사용자의 친구가 아닌 사람의 사진
+}
+
+data class CoordinateImageRequest(
+    @field:Longitude
+    val leftLongitude: Double,
+    @field:Latitude
+    val bottomLatitude: Double,
+    @field:Longitude
+    val rightLongitude: Double,
+    @field:Latitude
+    val topLatitude: Double,
+    @field:Positive(message = "사이즈는 양수여야 합니다.")
+    val size: Int = 10,
+)

--- a/src/main/kotlin/kr/weit/odya/service/dto/ImageDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/service/dto/ImageDtos.kt
@@ -31,3 +31,27 @@ data class LifeShotRequest(
     @field:Length(max = 30, message = "장소명의 최대 길이를 초과했습니다.")
     val placeName: String?, // 이때 받은 내용으로 검색을 하거나 통계를 내지 않기 때문에 장소 id가 아니라 장소 명을 받는다
 )
+
+data class CoordinateImageResponse(
+    val imageId: Long,
+    val userId: Long,
+    val imageUrl: String,
+    val placeId: String,
+    val latitude: Double,
+    val longitude: Double,
+    val journalId: Long?,
+    val communityId: Long?,
+) {
+    companion object {
+        fun of(image: ContentImage, url: String) = CoordinateImageResponse(
+            image.id,
+            image.user.id,
+            url,
+            image.placeId!!,
+            image.coordinate!!.y,
+            image.coordinate!!.x,
+            image.travelJournalContentImage?.id,
+            image.communityContentImage?.id,
+        )
+    }
+}

--- a/src/main/kotlin/kr/weit/odya/service/dto/ImageDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/service/dto/ImageDtos.kt
@@ -63,7 +63,7 @@ data class CoordinateImageResponse(
 
 enum class ImageUserType {
     USER, // 요청한 사용자 본인의 사진
-    FIEND, // 요청한 사용자의 친구의 사진
+    FRIEND, // 요청한 사용자의 친구의 사진
     OTHER, // 요청한 사용자의 친구가 아닌 사람의 사진
 }
 

--- a/src/main/kotlin/kr/weit/odya/support/validator/Latitude.kt
+++ b/src/main/kotlin/kr/weit/odya/support/validator/Latitude.kt
@@ -1,0 +1,18 @@
+package kr.weit.odya.support.validator
+
+import jakarta.validation.Constraint
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import kotlin.reflect.KClass
+
+@Min(-90)
+@Max(90)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Constraint(validatedBy = [])
+annotation class Latitude(
+    val message: String = "위도는 -90 ~ 90 사이의 값이어야 합니다.",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<Any>> = [],
+)

--- a/src/main/kotlin/kr/weit/odya/support/validator/Latitude.kt
+++ b/src/main/kotlin/kr/weit/odya/support/validator/Latitude.kt
@@ -5,14 +5,14 @@ import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import kotlin.reflect.KClass
 
-@Min(-90)
-@Max(90)
-@Target(AnnotationTarget.VALUE_PARAMETER)
+@Min(-90, message = "위도는 -90 이상이어야 합니다.")
+@Max(90, message = "위도는 90 이하여야 합니다.")
+@Target(AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
 @Constraint(validatedBy = [])
 annotation class Latitude(
-    val message: String = "위도는 -90 ~ 90 사이의 값이어야 합니다.",
+    val message: String = "",
     val groups: Array<KClass<*>> = [],
     val payload: Array<KClass<Any>> = [],
 )

--- a/src/main/kotlin/kr/weit/odya/support/validator/Longitude.kt
+++ b/src/main/kotlin/kr/weit/odya/support/validator/Longitude.kt
@@ -1,0 +1,19 @@
+package kr.weit.odya.support.validator
+
+import jakarta.validation.Constraint
+import jakarta.validation.Payload
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import kotlin.reflect.KClass
+
+@Min(-180)
+@Max(180)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Constraint(validatedBy = [])
+annotation class Longitude(
+    val message: String = "경도는 -180 ~ 180 사이의 값이어야 합니다.",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = [],
+)

--- a/src/main/kotlin/kr/weit/odya/support/validator/Longitude.kt
+++ b/src/main/kotlin/kr/weit/odya/support/validator/Longitude.kt
@@ -6,14 +6,14 @@ import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import kotlin.reflect.KClass
 
-@Min(-180)
-@Max(180)
-@Target(AnnotationTarget.VALUE_PARAMETER)
+@Min(-180, message = "경도는 -180 이상이어야 합니다.")
+@Max(180, message = "경도는 180 이하여야 합니다.")
+@Target(AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
 @Constraint(validatedBy = [])
 annotation class Longitude(
-    val message: String = "경도는 -180 ~ 180 사이의 값이어야 합니다.",
+    val message: String = "",
     val groups: Array<KClass<*>> = [],
     val payload: Array<KClass<out Payload>> = [],
 )

--- a/src/test/kotlin/kr/weit/odya/domain/contentImage/ContentImageRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/odya/domain/contentImage/ContentImageRepositoryTest.kt
@@ -9,9 +9,12 @@ import kr.weit.odya.domain.contentimage.getImageByUserId
 import kr.weit.odya.domain.contentimage.getLifeShotByUserId
 import kr.weit.odya.domain.user.User
 import kr.weit.odya.domain.user.UserRepository
+import kr.weit.odya.support.TEST_BOTTOM_LATITUDE
 import kr.weit.odya.support.TEST_DEFAULT_SIZE
+import kr.weit.odya.support.TEST_LEFT_LONGITUDE
+import kr.weit.odya.support.TEST_RIGHT_LONGITUDE
+import kr.weit.odya.support.TEST_TOP_LATITUDE
 import kr.weit.odya.support.createContentImage
-import kr.weit.odya.support.createCoordinateImageRequest
 import kr.weit.odya.support.createOtherUser
 import kr.weit.odya.support.createPlaceDetails
 import kr.weit.odya.support.createUser
@@ -77,7 +80,13 @@ class ContentImageRepositoryTest(private val userRepository: UserRepository, pri
 
         context("좌표로 contentImage 조회") {
             expect("좌표에 해당하는 contentImage를 조회한다") {
-                val images = contentImageRepository.getImageByRectangle(createCoordinateImageRequest())
+                val images = contentImageRepository.getImageByRectangle(
+                    TEST_LEFT_LONGITUDE,
+                    TEST_BOTTOM_LATITUDE,
+                    TEST_RIGHT_LONGITUDE,
+                    TEST_TOP_LATITUDE,
+                    TEST_DEFAULT_SIZE,
+                )
                 images.size shouldBe 1
                 images[0].id shouldBe contentImage2.id
             }

--- a/src/test/kotlin/kr/weit/odya/domain/contentImage/ContentImageRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/odya/domain/contentImage/ContentImageRepositoryTest.kt
@@ -4,14 +4,16 @@ import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.matchers.shouldBe
 import kr.weit.odya.domain.contentimage.ContentImage
 import kr.weit.odya.domain.contentimage.ContentImageRepository
+import kr.weit.odya.domain.contentimage.getImageByRectangle
 import kr.weit.odya.domain.contentimage.getImageByUserId
 import kr.weit.odya.domain.contentimage.getLifeShotByUserId
 import kr.weit.odya.domain.user.User
 import kr.weit.odya.domain.user.UserRepository
 import kr.weit.odya.support.TEST_DEFAULT_SIZE
-import kr.weit.odya.support.TEST_PLACE_NAME
 import kr.weit.odya.support.createContentImage
+import kr.weit.odya.support.createCoordinateImageRequest
 import kr.weit.odya.support.createOtherUser
+import kr.weit.odya.support.createPlaceDetails
 import kr.weit.odya.support.createUser
 import kr.weit.odya.support.test.BaseTests.RepositoryTest
 
@@ -23,11 +25,13 @@ class ContentImageRepositoryTest(private val userRepository: UserRepository, pri
         lateinit var user: User
         beforeEach {
             user = userRepository.save(createUser())
-            contentImage1 = contentImageRepository.save(createContentImage(user = user)).apply { setLifeShotInfo(TEST_PLACE_NAME) }
-            contentImage2 = contentImageRepository.save(createContentImage(user = user)).apply { setLifeShotInfo(null) }
-            contentImageRepository.save(createContentImage(user = user)).apply { setLifeShotInfo(TEST_PLACE_NAME) }
+            contentImage1 = contentImageRepository.save(createContentImage(user = user, placeDetails = createPlaceDetails(lat = 10.0, lng = 10.0), isLifeShot = true))
+            contentImage2 = contentImageRepository.save(createContentImage(user = user, placeDetails = createPlaceDetails(lat = 1.0, lng = 1.0), isLifeShot = true, placeName = null))
+            contentImageRepository.save(
+                createContentImage(user = user, placeDetails = createPlaceDetails(lat = -1.0, lng = -1.0), isLifeShot = true),
+            )
             contentImageRepository.save(createContentImage(user = user))
-            contentImageRepository.save(createContentImage(user = userRepository.save(createOtherUser()))).apply { setLifeShotInfo(TEST_PLACE_NAME) }
+            contentImageRepository.save(createContentImage(user = userRepository.save(createOtherUser()), isLifeShot = true))
         }
 
         context("contentImage 삭제") {
@@ -68,6 +72,14 @@ class ContentImageRepositoryTest(private val userRepository: UserRepository, pri
 
             expect("userId와 일치하는 인생샷을 lastId 이전으로 조회한다") {
                 contentImageRepository.getLifeShotByUserId(user.id, TEST_DEFAULT_SIZE, contentImage2.id).size shouldBe 1
+            }
+        }
+
+        context("좌표로 contentImage 조회") {
+            expect("좌표에 해당하는 contentImage를 조회한다") {
+                val images = contentImageRepository.getImageByRectangle(createCoordinateImageRequest())
+                images.size shouldBe 1
+                images[0].id shouldBe contentImage2.id
             }
         }
     },

--- a/src/test/kotlin/kr/weit/odya/domain/follow/FollowRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/odya/domain/follow/FollowRepositoryTest.kt
@@ -242,5 +242,12 @@ class FollowRepositoryTest(
                 result shouldBe emptyList()
             }
         }
+
+        context("getFollowingIds") {
+            expect("팔로잉 id list를 조회한다") {
+                val result = followRepository.getFollowingIds(follower.id)
+                result shouldBe listOf(following.id)
+            }
+        }
     },
 )

--- a/src/test/kotlin/kr/weit/odya/service/ImageServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/ImageServiceTest.kt
@@ -14,10 +14,15 @@ import kr.weit.odya.domain.contentimage.getImageByUserId
 import kr.weit.odya.domain.contentimage.getLifeShotByUserId
 import kr.weit.odya.domain.follow.FollowRepository
 import kr.weit.odya.domain.follow.getFollowingIds
+import kr.weit.odya.support.TEST_BOTTOM_LATITUDE
+import kr.weit.odya.support.TEST_DEFAULT_SIZE
 import kr.weit.odya.support.TEST_FILE_AUTHENTICATED_URL
 import kr.weit.odya.support.TEST_IMAGE_ID
+import kr.weit.odya.support.TEST_LEFT_LONGITUDE
 import kr.weit.odya.support.TEST_OTHER_USER_ID
+import kr.weit.odya.support.TEST_RIGHT_LONGITUDE
 import kr.weit.odya.support.TEST_SIZE
+import kr.weit.odya.support.TEST_TOP_LATITUDE
 import kr.weit.odya.support.TEST_USER_ID
 import kr.weit.odya.support.createContentImage
 import kr.weit.odya.support.createCoordinateImageRequest
@@ -125,7 +130,15 @@ class ImageServiceTest : DescribeSpec(
         describe("getImagesWithCoordinate") {
             context("유효한 유저 id와 좌표가 주어지는 경우") {
                 every { followRepository.getFollowingIds(TEST_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
-                every { contentImageRepository.getImageByRectangle(any()) } returns listOf(createContentImage(placeDetails = createPlaceDetails()))
+                every {
+                    contentImageRepository.getImageByRectangle(
+                        TEST_LEFT_LONGITUDE,
+                        TEST_BOTTOM_LATITUDE,
+                        TEST_RIGHT_LONGITUDE,
+                        TEST_TOP_LATITUDE,
+                        TEST_DEFAULT_SIZE,
+                    )
+                } returns listOf(createContentImage(placeDetails = createPlaceDetails()))
                 every { fileService.getPreAuthenticatedObjectUrl(any()) } returns TEST_FILE_AUTHENTICATED_URL
                 it("정상적으로 종료한다.") {
                     shouldNotThrowAny {

--- a/src/test/kotlin/kr/weit/odya/support/ContentImageFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/ContentImageFixtures.kt
@@ -5,13 +5,25 @@ import com.google.maps.model.LatLng
 import com.google.maps.model.PlaceDetails
 import kr.weit.odya.domain.contentimage.ContentImage
 import kr.weit.odya.domain.user.User
+import kr.weit.odya.service.dto.CoordinateImageRequest
+import kr.weit.odya.service.dto.CoordinateImageResponse
 import kr.weit.odya.service.dto.ImageResponse
+import kr.weit.odya.service.dto.ImageUserType
 import kr.weit.odya.service.dto.SliceResponse
 
 const val TEST_IMAGE_ID = 1L
 const val TEST_INVALID_IMAGE_ID = -1L
 const val TEST_IMAGE_URL: String = "testImageUrl"
 const val TEST_PLACE_NAME: String = "testPlaceName"
+const val TEST_LEFT_LONGITUDE: Double = 0.0
+const val TEST_BOTTOM_LATITUDE: Double = 0.0
+const val TEST_RIGHT_LONGITUDE: Double = 10.0
+const val TEST_TOP_LATITUDE: Double = 10.0
+
+const val LEFT_LONGITUDE_PARAM = "leftLongitude"
+const val BOTTOM_LATITUDE_PARAM = "bottomLatitude"
+const val RIGHT_LONGITUDE_PARAM = "rightLongitude"
+const val TOP_LATITUDE_PARAM = "topLatitude"
 
 val TEST_CONTENT_IMAGES = listOf(
     createContentImage(),
@@ -23,11 +35,16 @@ fun createContentImage(
     originName: String = TEST_IMAGE_FILE_WEBP,
     user: User = createUser(),
     isLifeShot: Boolean = false,
+    placeDetails: PlaceDetails? = null,
+    placeName: String? = TEST_PLACE_NAME,
 ) = ContentImage(
     name = name,
     originName = originName,
     user = user,
-).apply { if (isLifeShot) setLifeShotInfo(TEST_PLACE_NAME) }
+).apply {
+    if (isLifeShot) setLifeShotInfo(placeName)
+    if (placeDetails != null) setPlace(placeDetails)
+}
 
 fun createOtherContentImage(
     name: String = TEST_OTHER_GENERATED_FILE_NAME,
@@ -46,8 +63,41 @@ fun createSliceImageResponse() = SliceResponse(
     content = listOf(createImageResponse()),
 )
 
-fun createPlaceDetails() = PlaceDetails().apply {
-    geometry = Geometry().apply { location = LatLng(0.0, 0.0) }
+fun createPlaceDetails(lat: Double = TEST_BOTTOM_LATITUDE, lng: Double = TEST_LEFT_LONGITUDE, placeId: String = TEST_PLACE_ID) = PlaceDetails().apply {
+    this.placeId = placeId
+    geometry = Geometry().apply { location = LatLng(lat, lng) }
 }
 
 fun createPlaceDetailsMap() = mapOf(TEST_PLACE_ID to createPlaceDetails())
+
+fun createCoordinateImageRequest(
+    leftLongitude: Double = TEST_LEFT_LONGITUDE,
+    bottomLatitude: Double = TEST_BOTTOM_LATITUDE,
+    rightLongitude: Double = TEST_RIGHT_LONGITUDE,
+    topLatitude: Double = TEST_TOP_LATITUDE,
+    size: Int = TEST_DEFAULT_SIZE,
+) = CoordinateImageRequest(leftLongitude, bottomLatitude, rightLongitude, topLatitude, size)
+
+fun createCoordinateImageResponse(
+    imageId: Long = TEST_IMAGE_ID,
+    userId: Long = TEST_USER_ID,
+    imageUrl: String = TEST_IMAGE_URL,
+    placeId: String = TEST_PLACE_ID,
+    latitude: Double = TEST_BOTTOM_LATITUDE,
+    longitude: Double = TEST_LEFT_LONGITUDE,
+    imageUserType: ImageUserType = ImageUserType.USER,
+    travelJournalId: Long? = TEST_TRAVEL_JOURNAL_ID,
+    communityId: Long? = TEST_COMMUNITY_ID,
+) = CoordinateImageResponse(
+    imageId,
+    userId,
+    imageUrl,
+    placeId,
+    latitude,
+    longitude,
+    imageUserType,
+    travelJournalId,
+    communityId,
+)
+
+fun createCoordinateImageResponseList() = listOf(createCoordinateImageResponse())

--- a/src/test/kotlin/kr/weit/odya/support/SQLSupport.kt
+++ b/src/test/kotlin/kr/weit/odya/support/SQLSupport.kt
@@ -1,0 +1,18 @@
+package kr.weit.odya.support
+
+import org.h2gis.functions.spatial.predicates.ST_Within
+import org.locationtech.jts.geom.Geometry
+import java.sql.SQLException
+
+class SQLSupport {
+
+    companion object {
+        // 귀찮게도 Oracle과 H2의 ST_Relate 의 인자 순서가 반대다.
+        // 따라서 H2의 인자 순서를 오라클이랑 동일하게 맞춘다
+        @Throws(SQLException::class)
+        @JvmStatic
+        fun within(a: Geometry, b: Geometry): Boolean {
+            return ST_Within.isWithin(b, a)
+        }
+    }
+}

--- a/src/test/resources/sql/schema-h2.sql
+++ b/src/test/resources/sql/schema-h2.sql
@@ -1,3 +1,10 @@
+CREATE ALIAS IF NOT EXISTS H2GIS_SPATIAL FOR "org.h2gis.functions.factory.H2GISFunctions.load";
+CALL H2GIS_SPATIAL();
+
+DROP ALIAS ST_WITHIN;
+CREATE ALIAS ST_WITHIN FOR "kr.weit.odya.support.SQLSupport.within";
+CREATE ALIAS rectangle FOR "org.h2gis.functions.spatial.create.ST_MakeEnvelope.makeEnvelope";
+
 CREATE TABLE users
 (
     id           NUMERIC(19, 0) NOT NULL,


### PR DESCRIPTION
### 개요
- 메인 화면에서는 사용자들이 작성한 커뮤니티와 여행일지에 태그된 장소들이 마커로 보여야 한다

### 변경사항
- 커뮤니티와 여행일지에 장소가 태그되어있으면 추출해서 API 로 내려줌

### 관련 지라 및 위키 링크
- [ODYA-152](https://weit.atlassian.net/browse/ODYA-152)

### 리뷰어에게 하고 싶은 말
- 예전에 mysql로 했을땐 이렇게 어렵진 않았던것 같은데 이상할 정도로 hiberante spatial 어렵네요 ㄷㄷ
