### PR TITLE
ODYA-177 커뮤니티 목록 응답 값 수정

### DIFF
--- a/src/main/kotlin/kr/weit/odya/controller/CommunityController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/CommunityController.kt
@@ -8,6 +8,7 @@ import kr.weit.odya.security.LoginUserId
 import kr.weit.odya.service.CommunityService
 import kr.weit.odya.service.dto.CommunityCreateRequest
 import kr.weit.odya.service.dto.CommunityResponse
+import kr.weit.odya.service.dto.CommunitySimpleResponse
 import kr.weit.odya.service.dto.CommunitySummaryResponse
 import kr.weit.odya.service.dto.CommunityUpdateRequest
 import kr.weit.odya.service.dto.SliceResponse
@@ -80,7 +81,7 @@ class CommunityController(
         lastId: Long?,
         @RequestParam("sortType", defaultValue = "LATEST", required = false)
         sortType: CommunitySortType,
-    ): ResponseEntity<SliceResponse<CommunitySummaryResponse>> {
+    ): ResponseEntity<SliceResponse<CommunitySimpleResponse>> {
         val response = communityService.getMyCommunities(userId, size, lastId, sortType)
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/kr/weit/odya/service/dto/CommunityDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/service/dto/CommunityDtos.kt
@@ -86,8 +86,11 @@ data class CommunityContentImageResponse(
 
 data class CommunitySummaryResponse(
     val communityId: Long,
+    val communityContent: String,
     val communityMainImageUrl: String,
     val placeId: String?,
+    val writer: UserSimpleResponse,
+    val travelJournalSimpleResponse: TravelJournalSimpleResponse? = null,
     val communityCommentCount: Int,
     val communityLikeCount: Int,
 ) {
@@ -95,12 +98,25 @@ data class CommunitySummaryResponse(
         fun from(
             community: Community,
             communityMainImageUrl: String,
+            writerProfileUrl: String,
+            isFollowing: Boolean,
             communityCommentCount: Int,
         ): CommunitySummaryResponse =
             CommunitySummaryResponse(
                 communityId = community.id,
+                communityContent = community.content,
                 communityMainImageUrl = communityMainImageUrl,
                 placeId = community.placeId,
+                writer = UserSimpleResponse(community.user, writerProfileUrl, isFollowing),
+                travelJournalSimpleResponse = if (community.travelJournal != null) {
+                    TravelJournalSimpleResponse(
+                        travelJournalId = community.travelJournal!!.id,
+                        title = community.travelJournal!!.title,
+                        null,
+                    )
+                } else {
+                    null
+                },
                 communityCommentCount = communityCommentCount,
                 communityLikeCount = community.likeCount,
             )
@@ -124,4 +140,22 @@ data class CommunityUpdateRequest(
         visibility = visibility,
         placeId = placeId,
     )
+}
+
+data class CommunitySimpleResponse(
+    val communityId: Long,
+    val communityMainImageUrl: String,
+    val placeId: String?,
+) {
+    companion object {
+        fun from(
+            community: Community,
+            communityMainImageUrl: String,
+        ): CommunitySimpleResponse =
+            CommunitySimpleResponse(
+                communityId = community.id,
+                communityMainImageUrl = communityMainImageUrl,
+                placeId = community.placeId,
+            )
+    }
 }

--- a/src/main/kotlin/kr/weit/odya/service/dto/TravelJournalDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/service/dto/TravelJournalDtos.kt
@@ -242,7 +242,7 @@ data class TravelJournalSummaryResponse(
 data class TravelJournalSimpleResponse(
     val travelJournalId: Long,
     val title: String,
-    val mainImageUrl: String,
+    val mainImageUrl: String?,
 )
 
 data class TaggedTravelJournalResponse(

--- a/src/test/kotlin/kr/weit/odya/controller/CommunityControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/CommunityControllerTest.kt
@@ -35,7 +35,8 @@ import kr.weit.odya.support.createCommunityResponse
 import kr.weit.odya.support.createCommunityUpdateRequest
 import kr.weit.odya.support.createMockImageFile
 import kr.weit.odya.support.createMockOtherImageFile
-import kr.weit.odya.support.createSliceCommunityResponse
+import kr.weit.odya.support.createSliceCommunitySimpleResponse
+import kr.weit.odya.support.createSliceCommunitySummaryResponse
 import kr.weit.odya.support.createUpdateCommunityContentImagePairs
 import kr.weit.odya.support.test.BaseTests.UnitControllerTestEnvironment
 import kr.weit.odya.support.test.ControllerTestHelper.Companion.jsonContent
@@ -524,7 +525,7 @@ class CommunityControllerTest(
         describe("GET /api/v1/communities") {
             val targetUri = "/api/v1/communities"
             context("유효한 요청 데이터가 전달되면") {
-                val response = createSliceCommunityResponse()
+                val response = createSliceCommunitySummaryResponse()
                 every {
                     communityService.getCommunities(
                         TEST_USER_ID,
@@ -554,8 +555,20 @@ class CommunityControllerTest(
                                 responseBody(
                                     "hasNext" type JsonFieldType.BOOLEAN description "다음 페이지 존재 여부" example response.hasNext,
                                     "content[].communityId" type JsonFieldType.NUMBER description "커뮤니티 아이디" example response.content[0].communityId,
+                                    "content[].communityContent" type JsonFieldType.STRING description "커뮤니티 내용" example response.content[0].communityContent,
                                     "content[].communityMainImageUrl" type JsonFieldType.STRING description "커뮤니티 대표 이미지 URL" example response.content[0].communityMainImageUrl,
                                     "content[].placeId" type JsonFieldType.STRING description "장소 아이디" example response.content[0].placeId isOptional true,
+                                    "content[].writer.userId" type JsonFieldType.NUMBER description "작성자 아이디" example response.content[0].writer.userId,
+                                    "content[].writer.nickname" type JsonFieldType.STRING description "작성자 닉네임" example response.content[0].writer.nickname,
+                                    "content[].writer.isFollowing" type JsonFieldType.BOOLEAN description "작성자를 팔로우 중인지 여부" example response.content[0].writer.isFollowing,
+                                    "content[].writer.profile.profileUrl" type JsonFieldType.STRING description "작성자 프로필 이미지 URL" example response.content[0].writer.profile.profileUrl,
+                                    "content[].writer.profile.profileColor.colorHex" type JsonFieldType.STRING description "작성자 프로필 색상" example response.content[0].writer.profile.profileColor?.colorHex isOptional true,
+                                    "content[].writer.profile.profileColor.red" type JsonFieldType.NUMBER description "작성자 프로필 색상의 빨간색 값" example response.content[0].writer.profile.profileColor?.red isOptional true,
+                                    "content[].writer.profile.profileColor.green" type JsonFieldType.NUMBER description "작성자 프로필 색상의 초록색 값" example response.content[0].writer.profile.profileColor?.green isOptional true,
+                                    "content[].writer.profile.profileColor.blue" type JsonFieldType.NUMBER description "작성자 프로필 색상의 파란색 값" example response.content[0].writer.profile.profileColor?.blue isOptional true,
+                                    "content[].travelJournalSimpleResponse.travelJournalId" type JsonFieldType.NUMBER description "여행 일지 아이디" example response.content[0].travelJournalSimpleResponse?.travelJournalId isOptional true,
+                                    "content[].travelJournalSimpleResponse.title" type JsonFieldType.STRING description "여행 일지 제목" example response.content[0].travelJournalSimpleResponse?.title isOptional true,
+                                    "content[].travelJournalSimpleResponse.mainImageUrl" type JsonFieldType.STRING description "여행 일지 대표 이미지 URL" example response.content[0].travelJournalSimpleResponse?.mainImageUrl isOptional true,
                                     "content[].communityCommentCount" type JsonFieldType.NUMBER description "커뮤니티 댓글 수" example response.content[0].communityCommentCount,
                                     "content[].communityLikeCount" type JsonFieldType.NUMBER description "커뮤니티 좋아요 수" example response.content[0].communityLikeCount,
                                 ),
@@ -592,7 +605,7 @@ class CommunityControllerTest(
         describe("GET /api/v1/communities/me") {
             val targetUri = "/api/v1/communities/me"
             context("유효한 요청 데이터가 전달되면") {
-                val response = createSliceCommunityResponse()
+                val response = createSliceCommunitySimpleResponse()
                 every {
                     communityService.getMyCommunities(
                         TEST_USER_ID,
@@ -624,8 +637,6 @@ class CommunityControllerTest(
                                     "content[].communityId" type JsonFieldType.NUMBER description "커뮤니티 아이디" example response.content[0].communityId,
                                     "content[].communityMainImageUrl" type JsonFieldType.STRING description "커뮤니티 대표 이미지 URL" example response.content[0].communityMainImageUrl,
                                     "content[].placeId" type JsonFieldType.STRING description "장소 아이디" example response.content[0].placeId isOptional true,
-                                    "content[].communityCommentCount" type JsonFieldType.NUMBER description "커뮤니티 댓글 수" example response.content[0].communityCommentCount,
-                                    "content[].communityLikeCount" type JsonFieldType.NUMBER description "커뮤니티 좋아요 수" example response.content[0].communityLikeCount,
                                 ),
                             )
                         }
@@ -660,7 +671,7 @@ class CommunityControllerTest(
         describe("GET /api/v1/communities/friends") {
             val targetUri = "/api/v1/communities/friends"
             context("유효한 요청 데이터가 전달되면") {
-                val response = createSliceCommunityResponse()
+                val response = createSliceCommunitySummaryResponse()
                 every {
                     communityService.getFriendCommunities(
                         TEST_USER_ID,
@@ -690,8 +701,20 @@ class CommunityControllerTest(
                                 responseBody(
                                     "hasNext" type JsonFieldType.BOOLEAN description "다음 페이지 존재 여부" example response.hasNext,
                                     "content[].communityId" type JsonFieldType.NUMBER description "커뮤니티 아이디" example response.content[0].communityId,
+                                    "content[].communityContent" type JsonFieldType.STRING description "커뮤니티 내용" example response.content[0].communityContent,
                                     "content[].communityMainImageUrl" type JsonFieldType.STRING description "커뮤니티 대표 이미지 URL" example response.content[0].communityMainImageUrl,
                                     "content[].placeId" type JsonFieldType.STRING description "장소 아이디" example response.content[0].placeId isOptional true,
+                                    "content[].writer.userId" type JsonFieldType.NUMBER description "작성자 아이디" example response.content[0].writer.userId,
+                                    "content[].writer.nickname" type JsonFieldType.STRING description "작성자 닉네임" example response.content[0].writer.nickname,
+                                    "content[].writer.isFollowing" type JsonFieldType.BOOLEAN description "작성자를 팔로우 중인지 여부" example response.content[0].writer.isFollowing,
+                                    "content[].writer.profile.profileUrl" type JsonFieldType.STRING description "작성자 프로필 이미지 URL" example response.content[0].writer.profile.profileUrl,
+                                    "content[].writer.profile.profileColor.colorHex" type JsonFieldType.STRING description "작성자 프로필 색상" example response.content[0].writer.profile.profileColor?.colorHex isOptional true,
+                                    "content[].writer.profile.profileColor.red" type JsonFieldType.NUMBER description "작성자 프로필 색상의 빨간색 값" example response.content[0].writer.profile.profileColor?.red isOptional true,
+                                    "content[].writer.profile.profileColor.green" type JsonFieldType.NUMBER description "작성자 프로필 색상의 초록색 값" example response.content[0].writer.profile.profileColor?.green isOptional true,
+                                    "content[].writer.profile.profileColor.blue" type JsonFieldType.NUMBER description "작성자 프로필 색상의 파란색 값" example response.content[0].writer.profile.profileColor?.blue isOptional true,
+                                    "content[].travelJournalSimpleResponse.travelJournalId" type JsonFieldType.NUMBER description "여행 일지 아이디" example response.content[0].travelJournalSimpleResponse?.travelJournalId isOptional true,
+                                    "content[].travelJournalSimpleResponse.title" type JsonFieldType.STRING description "여행 일지 제목" example response.content[0].travelJournalSimpleResponse?.title isOptional true,
+                                    "content[].travelJournalSimpleResponse.mainImageUrl" type JsonFieldType.STRING description "여행 일지 대표 이미지 URL" example response.content[0].travelJournalSimpleResponse?.mainImageUrl isOptional true,
                                     "content[].communityCommentCount" type JsonFieldType.NUMBER description "커뮤니티 댓글 수" example response.content[0].communityCommentCount,
                                     "content[].communityLikeCount" type JsonFieldType.NUMBER description "커뮤니티 좋아요 수" example response.content[0].communityLikeCount,
                                 ),

--- a/src/test/kotlin/kr/weit/odya/service/CommunityServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/CommunityServiceTest.kt
@@ -19,6 +19,7 @@ import kr.weit.odya.domain.community.CommunityUpdateEvent
 import kr.weit.odya.domain.community.CommunityVisibility
 import kr.weit.odya.domain.community.getByCommunityId
 import kr.weit.odya.domain.community.getCommunitySliceBy
+import kr.weit.odya.domain.community.getFriendCommunitySliceBy
 import kr.weit.odya.domain.community.getMyCommunitySliceBy
 import kr.weit.odya.domain.communitycomment.CommunityCommentRepository
 import kr.weit.odya.domain.communitycomment.deleteCommunityComments
@@ -307,6 +308,7 @@ class CommunityServiceTest : DescribeSpec(
                     )
                 } returns createAllCommunities()
                 every { fileService.getPreAuthenticatedObjectUrl(any()) } returns TEST_FILE_AUTHENTICATED_URL
+                every { followRepository.existsByFollowerIdAndFollowingId(any<Long>(), any<Long>()) } returns false
                 every { communityCommentRepository.countByCommunityId(any<Long>()) } returns TEST_COMMUNITY_COMMENT_COUNT
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
@@ -330,7 +332,7 @@ class CommunityServiceTest : DescribeSpec(
                 every { communityCommentRepository.countByCommunityId(any<Long>()) } returns TEST_COMMUNITY_COMMENT_COUNT
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
-                        communityService.getCommunities(TEST_USER_ID, 10, null, CommunitySortType.LATEST)
+                        communityService.getMyCommunities(TEST_USER_ID, 10, null, CommunitySortType.LATEST)
                     }
                 }
             }
@@ -339,7 +341,7 @@ class CommunityServiceTest : DescribeSpec(
         describe("getFriendCommunities") {
             context("유효한 데이터가 주어지는 경우") {
                 every {
-                    communityRepository.getMyCommunitySliceBy(
+                    communityRepository.getFriendCommunitySliceBy(
                         TEST_USER_ID,
                         10,
                         null,
@@ -347,10 +349,11 @@ class CommunityServiceTest : DescribeSpec(
                     )
                 } returns createFriendCommunities()
                 every { fileService.getPreAuthenticatedObjectUrl(any()) } returns TEST_FILE_AUTHENTICATED_URL
+                every { followRepository.existsByFollowerIdAndFollowingId(any<Long>(), any<Long>()) } returns false
                 every { communityCommentRepository.countByCommunityId(any<Long>()) } returns TEST_COMMUNITY_COMMENT_COUNT
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
-                        communityService.getCommunities(TEST_USER_ID, 10, null, CommunitySortType.LATEST)
+                        communityService.getFriendCommunities(TEST_USER_ID, 10, null, CommunitySortType.LATEST)
                     }
                 }
             }

--- a/src/test/kotlin/kr/weit/odya/support/CommunityFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/CommunityFixtures.kt
@@ -11,6 +11,7 @@ import kr.weit.odya.domain.user.User
 import kr.weit.odya.service.dto.CommunityContentImageResponse
 import kr.weit.odya.service.dto.CommunityCreateRequest
 import kr.weit.odya.service.dto.CommunityResponse
+import kr.weit.odya.service.dto.CommunitySimpleResponse
 import kr.weit.odya.service.dto.CommunitySummaryResponse
 import kr.weit.odya.service.dto.CommunityUpdateRequest
 import kr.weit.odya.service.dto.SliceResponse
@@ -177,16 +178,6 @@ fun createOtherCommunityResponse(
     TEST_IS_USER_LIKED,
 )
 
-fun createTravelJournalSimpleResponse(
-    id: Long = TEST_TRAVEL_JOURNAL_ID,
-    title: String = TEST_TRAVEL_JOURNAL_TITLE,
-    mainImageUrl: String = TEST_FILE_AUTHENTICATED_URL,
-) = TravelJournalSimpleResponse(
-    travelJournalId = id,
-    title = title,
-    mainImageUrl = mainImageUrl,
-)
-
 fun createCommunityTopicResponse(
     id: Long = TEST_TOPIC_ID,
     word: String = TEST_TOPIC,
@@ -204,32 +195,74 @@ fun createCommunityContentImageResponse(
 )
 
 fun createCommunitySummaryResponse(
-    id: Long = TEST_COMMUNITY_ID,
-    mainImageUrl: String = TEST_FILE_AUTHENTICATED_URL,
-) = CommunitySummaryResponse(
-    communityId = id,
-    communityMainImageUrl = mainImageUrl,
-    placeId = TEST_PLACE_ID,
-    communityCommentCount = TEST_COMMUNITY_COMMENT_COUNT,
-    communityLikeCount = TEST_COMMUNITY_LIKE_COUNT,
+    community: Community = createCommunity(
+        id = TEST_COMMUNITY_ID,
+        communityContentImages = listOf(createCommunityContentImage()),
+    ),
+    communityMainImageUrl: String = TEST_FILE_AUTHENTICATED_URL,
+    writerProfileUrl: String = TEST_FILE_AUTHENTICATED_URL,
+    isFollowing: Boolean = true,
+    communityCommentCount: Int = TEST_COMMUNITY_COMMENT_COUNT,
+) = CommunitySummaryResponse.from(
+    community = community,
+    communityMainImageUrl = communityMainImageUrl,
+    writerProfileUrl = writerProfileUrl,
+    isFollowing = isFollowing,
+    communityCommentCount = communityCommentCount,
 )
 
 fun createOtherCommunitySummaryResponse(
+    community: Community = createCommunity(
+        id = TEST_OTHER_COMMUNITY_ID,
+        communityContentImages = listOf(createCommunityContentImage()),
+        placeId = TEST_OTHER_PLACE_ID,
+    ),
+    communityMainImageUrl: String = TEST_FILE_AUTHENTICATED_URL,
+    writerProfileUrl: String = TEST_FILE_AUTHENTICATED_URL,
+    isFollowing: Boolean = true,
+    communityCommentCount: Int = TEST_COMMUNITY_COMMENT_COUNT,
+) = CommunitySummaryResponse.from(
+    community = community,
+    communityMainImageUrl = communityMainImageUrl,
+    writerProfileUrl = writerProfileUrl,
+    isFollowing = isFollowing,
+    communityCommentCount = communityCommentCount,
+)
+
+fun createCommunitySimpleResponse(
+    id: Long = TEST_COMMUNITY_ID,
+    mainImageUrl: String = TEST_FILE_AUTHENTICATED_URL,
+) = CommunitySimpleResponse(
+    communityId = id,
+    communityMainImageUrl = mainImageUrl,
+    placeId = TEST_PLACE_ID,
+)
+
+fun createOtherCommunitySimpleResponse(
     id: Long = TEST_OTHER_COMMUNITY_ID,
     mainImageUrl: String = TEST_FILE_AUTHENTICATED_URL,
-) = CommunitySummaryResponse(
+) = CommunitySimpleResponse(
     communityId = id,
     communityMainImageUrl = mainImageUrl,
     placeId = TEST_OTHER_PLACE_ID,
-    communityCommentCount = TEST_COMMUNITY_COMMENT_COUNT,
-    communityLikeCount = TEST_COMMUNITY_LIKE_COUNT,
 )
 
-fun createSliceCommunityResponse(
+fun createSliceCommunitySummaryResponse(
     hasNext: Boolean = false,
     content: List<CommunitySummaryResponse> = listOf(
         createCommunitySummaryResponse(),
         createOtherCommunitySummaryResponse(),
+    ),
+) = SliceResponse(
+    hasNext = hasNext,
+    content = content,
+)
+
+fun createSliceCommunitySimpleResponse(
+    hasNext: Boolean = false,
+    content: List<CommunitySimpleResponse> = listOf(
+        createCommunitySimpleResponse(),
+        createOtherCommunitySimpleResponse(),
     ),
 ) = SliceResponse(
     hasNext = hasNext,

--- a/src/test/kotlin/kr/weit/odya/support/TravelJournalFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/TravelJournalFixtures.kt
@@ -20,6 +20,7 @@ import kr.weit.odya.service.dto.TravelJournalContentResponse
 import kr.weit.odya.service.dto.TravelJournalContentUpdateRequest
 import kr.weit.odya.service.dto.TravelJournalRequest
 import kr.weit.odya.service.dto.TravelJournalResponse
+import kr.weit.odya.service.dto.TravelJournalSimpleResponse
 import kr.weit.odya.service.dto.TravelJournalSummaryResponse
 import kr.weit.odya.service.dto.TravelJournalUpdateRequest
 import kr.weit.odya.service.dto.UserSimpleResponse
@@ -368,3 +369,13 @@ fun createSliceTaggedTravelJournalResponse(): SliceResponse<TaggedTravelJournalR
         size = TEST_DEFAULT_SIZE,
         content = listOf(createTaggedTravelJournalResponse()),
     )
+
+fun createTravelJournalSimpleResponse(
+    id: Long = TEST_TRAVEL_JOURNAL_ID,
+    title: String = TEST_TRAVEL_JOURNAL_TITLE,
+    mainImageUrl: String = TEST_FILE_AUTHENTICATED_URL,
+) = TravelJournalSimpleResponse(
+    travelJournalId = id,
+    title = title,
+    mainImageUrl = mainImageUrl,
+)


### PR DESCRIPTION
### 개요
- 커뮤니티 목록 응답 값에 커뮤니티 내용, 유저 정보, 여행 일지 정보가 추가되어야 한다.
### 변경사항
- 커뮤니티 목록 응답 값에 빠진 부분 추가
### 관련 지라 및 위키 링크
- [ODYA-177](https://weit.atlassian.net/browse/ODYA-177)
### 리뷰어에게 하고 싶은 말
- 피그마를 보고 필요한 응답 값을 추가했는데 혹시라도 빠진 부분 있으면 코멘트 부탁드립니다!!!
