### PR TITLE
ODYA-193 커뮤니티에 유저가 좋아요 눌렀는지 확인

### DIFF
--- a/src/docs/asciidoc/overview.adoc
+++ b/src/docs/asciidoc/overview.adoc
@@ -28,6 +28,9 @@
 | `409 CONFLICT`
 | Request resource already exists
 
+| `413 Content Too Large`
+| Request content is too large
+
 | `500 INTERNAL_SERVER_ERROR`
 | Internal server error
 |===

--- a/src/main/kotlin/kr/weit/odya/service/CommunityService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/CommunityService.kt
@@ -316,12 +316,14 @@ class CommunityService(
                 fileService.getPreAuthenticatedObjectUrl(community.user.profile.profileName)
             val isFollowing = followRepository.existsByFollowerIdAndFollowingId(userId, community.user.id)
             val communityCommentCount = communityCommentRepository.countByCommunityId(community.id)
+            val isUserLiked = communityLikeRepository.existsByCommunityIdAndUserId(community.id, userId)
             CommunitySummaryResponse.from(
                 community,
                 communityMainImageUrl,
                 writerProfileUrl,
                 isFollowing,
                 communityCommentCount,
+                isUserLiked,
             )
         },
     )

--- a/src/main/kotlin/kr/weit/odya/service/dto/CommunityDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/service/dto/CommunityDtos.kt
@@ -103,6 +103,7 @@ data class CommunitySummaryResponse(
     val travelJournalSimpleResponse: TravelJournalSimpleResponse? = null,
     val communityCommentCount: Int,
     val communityLikeCount: Int,
+    val isUserLiked: Boolean,
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     val createdDate: LocalDateTime,
 ) {
@@ -113,6 +114,7 @@ data class CommunitySummaryResponse(
             writerProfileUrl: String,
             isFollowing: Boolean,
             communityCommentCount: Int,
+            isUserLiked: Boolean,
         ): CommunitySummaryResponse =
             CommunitySummaryResponse(
                 communityId = community.id,
@@ -129,6 +131,7 @@ data class CommunitySummaryResponse(
                 } else {
                     null
                 },
+                isUserLiked = isUserLiked,
                 communityCommentCount = communityCommentCount,
                 communityLikeCount = community.likeCount,
                 createdDate = community.createdDate,

--- a/src/test/kotlin/kr/weit/odya/controller/CommunityControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/CommunityControllerTest.kt
@@ -583,6 +583,7 @@ class CommunityControllerTest(
                                     "content[].travelJournalSimpleResponse.mainImageUrl" type JsonFieldType.STRING description "여행 일지 대표 이미지 URL" example response.content[0].travelJournalSimpleResponse?.mainImageUrl isOptional true,
                                     "content[].communityCommentCount" type JsonFieldType.NUMBER description "커뮤니티 댓글 수" example response.content[0].communityCommentCount,
                                     "content[].communityLikeCount" type JsonFieldType.NUMBER description "커뮤니티 좋아요 수" example response.content[0].communityLikeCount,
+                                    "content[].isUserLiked" type JsonFieldType.BOOLEAN description "사용자가 좋아요를 눌렀는지 여부" example response.content[0].isUserLiked,
                                     "content[].createdDate" type JsonFieldType.STRING description "커뮤니티 생성 날짜" example response.content[0].createdDate,
                                 ),
                             )
@@ -730,6 +731,7 @@ class CommunityControllerTest(
                                     "content[].travelJournalSimpleResponse.mainImageUrl" type JsonFieldType.STRING description "여행 일지 대표 이미지 URL" example response.content[0].travelJournalSimpleResponse?.mainImageUrl isOptional true,
                                     "content[].communityCommentCount" type JsonFieldType.NUMBER description "커뮤니티 댓글 수" example response.content[0].communityCommentCount,
                                     "content[].communityLikeCount" type JsonFieldType.NUMBER description "커뮤니티 좋아요 수" example response.content[0].communityLikeCount,
+                                    "content[].isUserLiked" type JsonFieldType.BOOLEAN description "사용자가 좋아요를 눌렀는지 여부" example response.content[0].isUserLiked,
                                     "content[].createdDate" type JsonFieldType.STRING description "커뮤니티 생성 날짜" example response.content[0].createdDate,
                                 ),
                             )
@@ -815,6 +817,7 @@ class CommunityControllerTest(
                                     "content[].travelJournalSimpleResponse.mainImageUrl" type JsonFieldType.STRING description "여행 일지 대표 이미지 URL" example response.content[0].travelJournalSimpleResponse?.mainImageUrl isOptional true,
                                     "content[].communityCommentCount" type JsonFieldType.NUMBER description "커뮤니티 댓글 수" example response.content[0].communityCommentCount,
                                     "content[].communityLikeCount" type JsonFieldType.NUMBER description "커뮤니티 좋아요 수" example response.content[0].communityLikeCount,
+                                    "content[].isUserLiked" type JsonFieldType.BOOLEAN description "사용자가 좋아요를 눌렀는지 여부" example response.content[0].isUserLiked,
                                     "content[].createdDate" type JsonFieldType.STRING description "커뮤니티 생성 날짜" example response.content[0].createdDate,
                                 ),
                             ),

--- a/src/test/kotlin/kr/weit/odya/service/CommunityServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/CommunityServiceTest.kt
@@ -320,6 +320,7 @@ class CommunityServiceTest : DescribeSpec(
                 every { fileService.getPreAuthenticatedObjectUrl(any()) } returns TEST_FILE_AUTHENTICATED_URL
                 every { followRepository.existsByFollowerIdAndFollowingId(any<Long>(), any<Long>()) } returns false
                 every { communityCommentRepository.countByCommunityId(any<Long>()) } returns TEST_COMMUNITY_COMMENT_COUNT
+                every { communityLikeRepository.existsByCommunityIdAndUserId(any<Long>(), any<Long>()) } returns true
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
                         communityService.getCommunities(TEST_USER_ID, 10, null, CommunitySortType.LATEST)
@@ -361,6 +362,7 @@ class CommunityServiceTest : DescribeSpec(
                 every { fileService.getPreAuthenticatedObjectUrl(any()) } returns TEST_FILE_AUTHENTICATED_URL
                 every { followRepository.existsByFollowerIdAndFollowingId(any<Long>(), any<Long>()) } returns false
                 every { communityCommentRepository.countByCommunityId(any<Long>()) } returns TEST_COMMUNITY_COMMENT_COUNT
+                every { communityLikeRepository.existsByCommunityIdAndUserId(any<Long>(), any<Long>()) } returns true
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
                         communityService.getFriendCommunities(TEST_USER_ID, 10, null, CommunitySortType.LATEST)
@@ -383,6 +385,7 @@ class CommunityServiceTest : DescribeSpec(
                 } returns createTopicCommunities()
                 every { fileService.getPreAuthenticatedObjectUrl(any()) } returns TEST_FILE_AUTHENTICATED_URL
                 every { communityCommentRepository.countByCommunityId(any<Long>()) } returns TEST_COMMUNITY_COMMENT_COUNT
+                every { communityLikeRepository.existsByCommunityIdAndUserId(any<Long>(), any<Long>()) } returns true
                 it("정상적으로 종료한다.") {
                     shouldNotThrowAny {
                         communityService.searchByTopic(

--- a/src/test/kotlin/kr/weit/odya/support/CommunityFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/CommunityFixtures.kt
@@ -219,12 +219,14 @@ fun createCommunitySummaryResponse(
     writerProfileUrl: String = TEST_FILE_AUTHENTICATED_URL,
     isFollowing: Boolean = true,
     communityCommentCount: Int = TEST_COMMUNITY_COMMENT_COUNT,
+    isUserLiked: Boolean = true,
 ) = CommunitySummaryResponse.from(
     community = community,
     communityMainImageUrl = communityMainImageUrl,
     writerProfileUrl = writerProfileUrl,
     isFollowing = isFollowing,
     communityCommentCount = communityCommentCount,
+    isUserLiked = isUserLiked,
 )
 
 fun createOtherCommunitySummaryResponse(
@@ -237,12 +239,14 @@ fun createOtherCommunitySummaryResponse(
     writerProfileUrl: String = TEST_FILE_AUTHENTICATED_URL,
     isFollowing: Boolean = true,
     communityCommentCount: Int = TEST_COMMUNITY_COMMENT_COUNT,
+    isUserLiked: Boolean = true,
 ) = CommunitySummaryResponse.from(
     community = community,
     communityMainImageUrl = communityMainImageUrl,
     writerProfileUrl = writerProfileUrl,
     isFollowing = isFollowing,
     communityCommentCount = communityCommentCount,
+    isUserLiked = isUserLiked,
 )
 
 fun createCommunitySimpleResponse(


### PR DESCRIPTION
### 개요
- 커뮤니티 목록조회할때 유저가 좋아요를 눌렀는지 확인할수 없다
- 413 statuscode에 대해 문서화가 안되어 있었다

### 변경사항
- 커뮤니티 목록 조회 결과에 좋아요 여부 필드 추가
- 413에러 문서화

### 관련 지라 및 위키 링크
- [ODYA-193](https://weit.atlassian.net/browse/ODYA-193)

### 리뷰어에게 하고 싶은 말
- 빠르게 쓱싹 했습니다 ㅋㅋㅋ
- 참고로 413에러는 저희 API 서버에서 내리는게 아니라 그 앞 인그레스가 내리는 응답이라 테스트 할수 없어서 테스트 코드는 없습니다 ㅎㅎ
