### PR TITLE
ODYA-203 최대 요청 바디 크기 제한 수정

### DIFF
--- a/src/main/kotlin/kr/weit/odya/controller/ExceptionHandler.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/ExceptionHandler.kt
@@ -10,6 +10,9 @@ import kr.weit.odya.security.FirebaseAuthException
 import kr.weit.odya.service.OdyaException
 import kr.weit.odya.service.dto.ErrorResponse
 import kr.weit.odya.support.exception.ErrorCode
+import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException
+import org.apache.tomcat.util.http.fileupload.impl.SizeException
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
@@ -161,6 +164,14 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
         val internalServerErrorCode = ErrorCode.INTERNAL_SERVER_ERROR
         return ResponseEntity.status(internalServerErrorCode.httpStatus)
             .body(ErrorResponse.of(internalServerErrorCode, ex.message))
+    }
+
+    @ExceptionHandler(SizeLimitExceededException::class, FileSizeLimitExceededException::class)
+    fun sizeLimitExceededException(ex: SizeException): ResponseEntity<ErrorResponse> {
+        logger.error("[SizeException]", ex)
+        val payloadTooLargeErrorCode = ErrorCode.PAYLOAD_TOO_LARGE
+        return ResponseEntity.status(payloadTooLargeErrorCode.httpStatus)
+            .body(ErrorResponse.of(payloadTooLargeErrorCode, ex.message))
     }
 
     private fun MethodArgumentNotValidException.messages(): List<String> {

--- a/src/main/kotlin/kr/weit/odya/support/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/odya/support/exception/ErrorCode.kt
@@ -16,6 +16,7 @@ enum class ErrorCode(val httpStatus: HttpStatus, val code: Int, val errorMessage
     UNREGISTERED_USER(HttpStatus.UNAUTHORIZED, -10005, "Unregistered user"),
     EXIST_RESOURCE(HttpStatus.CONFLICT, -10006, "Exist resource"),
     NOT_FOUND_DEFAULT_RESOURCE(HttpStatus.INTERNAL_SERVER_ERROR, -10007, "Not found default resource"),
+    PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, -10008, "Payload too large"),
     INVALID_FIREBASE_ID_TOKEN(HttpStatus.UNAUTHORIZED, -11000, "Invalid Firebase ID token"),
     FIREBASE_USER_CREATION_FAIL(HttpStatus.CONFLICT, -11001, "Firebase user creation fail"),
     FIREBASE_CUSTOM_TOKEN_CREATION_FAIL(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
   servlet:
     multipart:
       max-file-size: 25MB # 사진 1개당 약 100kb * 최대 15일까지 한번에 올릴수 있음 * 1일당 15장까지 올릴수 있음 + 10% 버퍼 = 25MB
+      max-request-size: 30MB # 최대 파일 사이즈 + 넉넉하게 5mb 버퍼 = 30MB
   cloud:
     compatibility-verifier:
       enabled: false


### PR DESCRIPTION
### 개요
- 이전에 요청 크기 제한을 해제 할때 파일사이즈 제한만 해제해서 request 전체 크기은 스프링 디폴트인 10MB로 남아 있었다

### 변경사항
- 최대 request size 설정 추가

### 관련 지라 및 위키 링크
- [ODYA-203](https://weit.atlassian.net/browse/ODYA-203)

### 리뷰어에게 하고 싶은 말
- 희오님의 제보로 설정이 빠졌다는걸 알아서 빠르게 쓱싹했습니다 ㅎㅎ..