### PR TITLE
ODYA-211 여행일지와 커뮤니티 placeId로 검색가능하게 수정

### DIFF
--- a/src/docs/asciidoc/community.adoc
+++ b/src/docs/asciidoc/community.adoc
@@ -79,7 +79,11 @@ operation::community-controller-test/community-get-fail-invalid-token[snippets='
 
 operation::community-controller-test/community-get-communities-success[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
 
-=== *3-2 실패 - 유효하지 않은 토큰인 경우*
+=== *3-2 실패 - placeId가 공백인 경우*
+
+operation::community-controller-test/community-get-communities-fail-blank-place-id[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *3-3 실패 - 유효하지 않은 토큰인 경우*
 
 operation::community-controller-test/community-get-communities-fail-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']
 

--- a/src/docs/asciidoc/travelJournal.adoc
+++ b/src/docs/asciidoc/travelJournal.adoc
@@ -154,7 +154,11 @@ operation::travel-journal-controller-test/get-travel-journals-fail-invalid-token
 
 operation::travel-journal-controller-test/get-my-travel-journals-success[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
 
-=== *4-2 실패 - 유효하지 않은 토큰일 경우*
+=== *4-2 실패 - placeId가 공백인 경우*
+
+operation::travel-journal-controller-test/get-my-travel-journals-fail-blank-place-id[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *4-3 실패 - 유효하지 않은 토큰일 경우*
 
 operation::travel-journal-controller-test/get-my-travel-journals-fail-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']
 
@@ -165,7 +169,11 @@ operation::travel-journal-controller-test/get-my-travel-journals-fail-invalid-to
 
 operation::travel-journal-controller-test/get-friend-travel-journals-success[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
 
-=== *5-2 실패 - 유효하지 않은 토큰일 경우*
+=== *5-2 실패 - placeId가 공백인 경우*
+
+operation::travel-journal-controller-test/get-friend-travel-journals-fail-blank-place-id[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *5-3 실패 - 유효하지 않은 토큰일 경우*
 
 operation::travel-journal-controller-test/get-friend-travel-journals-fail-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']
 
@@ -175,6 +183,10 @@ operation::travel-journal-controller-test/get-friend-travel-journals-fail-invali
 === *6-1 성공*
 
 operation::travel-journal-controller-test/get-recommend-travel-journals-success[snippets='http-request,request-headers,query-parameters,http-response,response-fields']
+
+=== *6-2 실패 - placeId가 공백인 경우*
+
+operation::travel-journal-controller-test/get-recommend-travel-journals-fail-blank-place-id[snippets='http-request,request-headers,query-parameters,http-response']
 
 === *6-2 실패 - 유효하지 않은 토큰일 경우*
 

--- a/src/main/kotlin/kr/weit/odya/controller/CommunityController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/CommunityController.kt
@@ -13,6 +13,7 @@ import kr.weit.odya.service.dto.CommunitySummaryResponse
 import kr.weit.odya.service.dto.CommunityUpdateRequest
 import kr.weit.odya.service.dto.CommunityWithCommentsResponse
 import kr.weit.odya.service.dto.SliceResponse
+import kr.weit.odya.support.validator.NullOrNotBlank
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -68,10 +69,13 @@ class CommunityController(
         @Positive(message = "마지막 ID는 양수여야 합니다.")
         @RequestParam("lastId", required = false)
         lastId: Long?,
+        @NullOrNotBlank(message = "placeId는 공백이면 안됩니다.")
+        @RequestParam(name = "placeId", required = false)
+        placeId: String?,
         @RequestParam("sortType", defaultValue = "LATEST", required = false)
         sortType: CommunitySortType,
     ): ResponseEntity<SliceResponse<CommunitySummaryResponse>> {
-        val response = communityService.getCommunities(userId, size, lastId, sortType)
+        val response = communityService.getCommunities(userId, size, lastId, placeId, sortType)
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/kotlin/kr/weit/odya/controller/TravelJournalController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/TravelJournalController.kt
@@ -13,6 +13,7 @@ import kr.weit.odya.service.dto.TravelJournalRequest
 import kr.weit.odya.service.dto.TravelJournalResponse
 import kr.weit.odya.service.dto.TravelJournalSummaryResponse
 import kr.weit.odya.service.dto.TravelJournalUpdateRequest
+import kr.weit.odya.support.validator.NullOrNotBlank
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -92,11 +93,14 @@ class TravelJournalController(private val travelJournalService: TravelJournalSer
         @Positive(message = "마지막 Id는 양수여야 합니다.")
         @RequestParam(name = "lastId", required = false)
         lastId: Long?,
+        @NullOrNotBlank(message = "placeId는 공백이면 안됩니다.")
+        @RequestParam(name = "placeId", required = false)
+        placeId: String?,
         @RequestParam(name = "sortType", required = false, defaultValue = "LATEST")
         sortType: TravelJournalSortType,
         @LoginUserId userId: Long,
     ): ResponseEntity<SliceResponse<TravelJournalSummaryResponse>> {
-        val response = travelJournalService.getMyTravelJournals(userId, size, lastId, sortType)
+        val response = travelJournalService.getMyTravelJournals(userId, size, lastId, placeId, sortType)
         return ResponseEntity.ok(response)
     }
 
@@ -108,11 +112,14 @@ class TravelJournalController(private val travelJournalService: TravelJournalSer
         @Positive(message = "마지막 Id는 양수여야 합니다.")
         @RequestParam(name = "lastId", required = false)
         lastId: Long?,
+        @NullOrNotBlank(message = "placeId는 공백이면 안됩니다.")
+        @RequestParam(name = "placeId", required = false)
+        placeId: String?,
         @RequestParam(name = "sortType", required = false, defaultValue = "LATEST")
         sortType: TravelJournalSortType,
         @LoginUserId userId: Long,
     ): ResponseEntity<SliceResponse<TravelJournalSummaryResponse>> {
-        val response = travelJournalService.getFriendTravelJournals(userId, size, lastId, sortType)
+        val response = travelJournalService.getFriendTravelJournals(userId, size, lastId, placeId, sortType)
         return ResponseEntity.ok(response)
     }
 
@@ -124,11 +131,14 @@ class TravelJournalController(private val travelJournalService: TravelJournalSer
         @Positive(message = "마지막 Id는 양수여야 합니다.")
         @RequestParam(name = "lastId", required = false)
         lastId: Long?,
+        @NullOrNotBlank(message = "placeId는 공백이면 안됩니다.")
+        @RequestParam(name = "placeId", required = false)
+        placeId: String?,
         @RequestParam(name = "sortType", required = false, defaultValue = "LATEST")
         sortType: TravelJournalSortType,
         @LoginUserId userId: Long,
     ): ResponseEntity<SliceResponse<TravelJournalSummaryResponse>> {
-        val response = travelJournalService.getRecommendTravelJournals(userId, size, lastId, sortType)
+        val response = travelJournalService.getRecommendTravelJournals(userId, size, lastId, placeId, sortType)
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/kotlin/kr/weit/odya/domain/community/CommunityRepository.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/community/CommunityRepository.kt
@@ -28,8 +28,9 @@ fun CommunityRepository.getCommunitySliceBy(
     userId: Long,
     size: Int,
     lastId: Long?,
+    placeId: String?,
     sortType: CommunitySortType,
-): List<Community> = findCommunitySliceBy(userId, size, lastId, sortType)
+): List<Community> = findCommunitySliceBy(userId, size, lastId, placeId, sortType)
 
 fun CommunityRepository.getMyCommunitySliceBy(
     userId: Long,
@@ -67,6 +68,7 @@ interface CustomCommunityRepository {
         userId: Long,
         size: Int,
         lastId: Long?,
+        placeId: String?,
         sortType: CommunitySortType,
     ): List<Community>
 
@@ -101,6 +103,7 @@ class CommunityRepositoryImpl(private val queryFactory: QueryFactory) : CustomCo
         userId: Long,
         size: Int,
         lastId: Long?,
+        placeId: String?,
         sortType: CommunitySortType,
     ): List<Community> = queryFactory.listQuery {
         getCommunitySliceBaseQuery(lastId, sortType, size)
@@ -115,6 +118,10 @@ class CommunityRepositoryImpl(private val queryFactory: QueryFactory) : CustomCo
                 col(Community::id).`in`(myFriendOnlyCommunityIds),
             ),
         )
+
+        if (placeId != null) {
+            where(nestedCol(col(Community::communityInformation), CommunityInformation::placeId).equal(placeId))
+        }
     }
 
     override fun findMyCommunitySliceBy(

--- a/src/main/kotlin/kr/weit/odya/service/CommunityService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/CommunityService.kt
@@ -119,9 +119,10 @@ class CommunityService(
         userId: Long,
         size: Int,
         lastId: Long?,
+        placeId: String?,
         sortType: CommunitySortType,
     ): SliceResponse<CommunitySummaryResponse> {
-        val communities = communityRepository.getCommunitySliceBy(userId, size, lastId, sortType)
+        val communities = communityRepository.getCommunitySliceBy(userId, size, lastId, placeId, sortType)
         return getCommunitySummarySliceResponse(size, communities, userId)
     }
 

--- a/src/main/kotlin/kr/weit/odya/service/TravelJournalService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/TravelJournalService.kt
@@ -189,9 +189,10 @@ class TravelJournalService(
         userId: Long,
         size: Int,
         lastId: Long?,
+        placeId: String?,
         sortType: TravelJournalSortType,
     ): SliceResponse<TravelJournalSummaryResponse> {
-        val travelJournals = travelJournalRepository.getMyTravelJournalSliceBy(userId, size, lastId, sortType)
+        val travelJournals = travelJournalRepository.getMyTravelJournalSliceBy(userId, size, lastId, placeId, sortType)
         return SliceResponse(
             size,
             getTravelJournalSimpleResponses(travelJournals),
@@ -203,9 +204,10 @@ class TravelJournalService(
         userId: Long,
         size: Int,
         lastId: Long?,
+        placeId: String?,
         sortType: TravelJournalSortType,
     ): SliceResponse<TravelJournalSummaryResponse> {
-        val travelJournals = travelJournalRepository.getFriendTravelJournalSliceBy(userId, size, lastId, sortType)
+        val travelJournals = travelJournalRepository.getFriendTravelJournalSliceBy(userId, size, lastId, placeId, sortType)
         return SliceResponse(
             size,
             getTravelJournalSimpleResponses(travelJournals),
@@ -217,10 +219,11 @@ class TravelJournalService(
         userId: Long,
         size: Int,
         lastId: Long?,
+        placeId: String?,
         sortType: TravelJournalSortType,
     ): SliceResponse<TravelJournalSummaryResponse> {
         val user = userRepository.getByUserId(userId)
-        val travelJournals = travelJournalRepository.getRecommendTravelJournalSliceBy(user, size, lastId, sortType)
+        val travelJournals = travelJournalRepository.getRecommendTravelJournalSliceBy(user, size, lastId, placeId, sortType)
         return SliceResponse(
             size,
             getTravelJournalSimpleResponses(travelJournals),

--- a/src/main/kotlin/kr/weit/odya/support/validator/NullOrNotBlank.kt
+++ b/src/main/kotlin/kr/weit/odya/support/validator/NullOrNotBlank.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.KClass
 
 @MustBeDocumented
 @Constraint(validatedBy = [NullOrNotBlankValidator::class])
-@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class NullOrNotBlank(
     val message: String = "",

--- a/src/test/kotlin/kr/weit/odya/controller/CommunityControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/CommunityControllerTest.kt
@@ -14,6 +14,7 @@ import kr.weit.odya.service.dto.CommunityUpdateRequest
 import kr.weit.odya.support.LAST_ID_PARAM
 import kr.weit.odya.support.MAX_COMMUNITY_CONTENT_IMAGE_COUNT
 import kr.weit.odya.support.MIM_COMMUNITY_CONTENT_IMAGE_COUNT
+import kr.weit.odya.support.PLACE_ID_PARAM
 import kr.weit.odya.support.SIZE_PARAM
 import kr.weit.odya.support.SOMETHING_ERROR_MESSAGE
 import kr.weit.odya.support.SORT_TYPE_PARAM
@@ -27,6 +28,7 @@ import kr.weit.odya.support.TEST_DEFAULT_SIZE
 import kr.weit.odya.support.TEST_INVALID_TOPIC_ID
 import kr.weit.odya.support.TEST_NOT_EXIST_TOPIC_ID
 import kr.weit.odya.support.TEST_NOT_EXIST_TRAVEL_JOURNAL_ID
+import kr.weit.odya.support.TEST_PLACE_ID
 import kr.weit.odya.support.TEST_TOPIC_ID
 import kr.weit.odya.support.TEST_UPDATE_IMAGE_FILE_WEBP
 import kr.weit.odya.support.TEST_USER_ID
@@ -544,12 +546,14 @@ class CommunityControllerTest(
                         TEST_USER_ID,
                         TEST_DEFAULT_SIZE,
                         null,
+                        TEST_PLACE_ID,
                         any<CommunitySortType>(),
                     )
                 } returns response
                 it("200 응답한다.") {
                     restDocMockMvc.get(targetUri) {
                         header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(PLACE_ID_PARAM, TEST_PLACE_ID)
                     }
                         .andExpect {
                             status { isOk() }
@@ -564,6 +568,7 @@ class CommunityControllerTest(
                                     SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
                                     LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example "null" isOptional true,
                                     SORT_TYPE_PARAM parameterDescription "정렬 타입" example CommunitySortType.values() isOptional true,
+                                    PLACE_ID_PARAM parameterDescription "장소 아이디" example TEST_PLACE_ID isOptional true,
                                 ),
                                 responseBody(
                                     "hasNext" type JsonFieldType.BOOLEAN description "다음 페이지 존재 여부" example response.hasNext,
@@ -586,6 +591,31 @@ class CommunityControllerTest(
                                     "content[].communityLikeCount" type JsonFieldType.NUMBER description "커뮤니티 좋아요 수" example response.content[0].communityLikeCount,
                                     "content[].isUserLiked" type JsonFieldType.BOOLEAN description "사용자가 좋아요를 눌렀는지 여부" example response.content[0].isUserLiked,
                                     "content[].createdDate" type JsonFieldType.STRING description "커뮤니티 생성 날짜" example response.content[0].createdDate,
+                                ),
+                            )
+                        }
+                }
+            }
+            context("placeId가 공백인 경우") {
+                it("400 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(PLACE_ID_PARAM, " ")
+                    }
+                        .andExpect {
+                            status { isBadRequest() }
+                        }
+                        .andDo {
+                            createDocument(
+                                "community-get-communities-fail-blank-place-id",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
+                                    LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example "null" isOptional true,
+                                    SORT_TYPE_PARAM parameterDescription "정렬 타입" example CommunitySortType.values() isOptional true,
+                                    PLACE_ID_PARAM parameterDescription "공백인 장소 id" example " " isOptional true,
                                 ),
                             )
                         }

--- a/src/test/kotlin/kr/weit/odya/controller/TravelJournalControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/TravelJournalControllerTest.kt
@@ -20,6 +20,7 @@ import kr.weit.odya.support.MAX_TRAVEL_COMPANION_COUNT
 import kr.weit.odya.support.MAX_TRAVEL_DAYS
 import kr.weit.odya.support.MAX_TRAVEL_JOURNAL_CONTENT_IMAGE_COUNT
 import kr.weit.odya.support.NOT_EXIST_USER_ERROR_MESSAGE
+import kr.weit.odya.support.PLACE_ID_PARAM
 import kr.weit.odya.support.SIZE_PARAM
 import kr.weit.odya.support.SOMETHING_ERROR_MESSAGE
 import kr.weit.odya.support.TEST_BEARER_ID_TOKEN
@@ -1194,12 +1195,14 @@ class TravelJournalControllerTest(
                         TEST_USER_ID,
                         TEST_DEFAULT_SIZE,
                         null,
+                        TEST_PLACE_ID,
                         any<TravelJournalSortType>(),
                     )
                 } returns response
                 it("200 응답한다.") {
                     restDocMockMvc.get(targetUri) {
                         header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(PLACE_ID_PARAM, TEST_PLACE_ID)
                     }.andExpect {
                         status { isOk() }
                     }.andDo {
@@ -1211,6 +1214,7 @@ class TravelJournalControllerTest(
                             queryParameters(
                                 SIZE_PARAM parameterDescription "데이터 개수 (default = 10)" example TEST_DEFAULT_SIZE isOptional true,
                                 LAST_ID_PARAM parameterDescription "마지막 여행 일지 ID" example TEST_TRAVEL_JOURNAL_ID isOptional true,
+                                PLACE_ID_PARAM parameterDescription "장소 아이디" example TEST_PLACE_ID isOptional true,
                             ),
                             responseBody(
                                 "hasNext" type JsonFieldType.BOOLEAN description "다음 페이지 여부" example response.hasNext,
@@ -1234,6 +1238,29 @@ class TravelJournalControllerTest(
                                 "content[].travelCompanionSimpleResponses[].profileUrl" type JsonFieldType.STRING description "여행 친구의 프로필 사진" example (
                                     response.content[0].travelCompanionSimpleResponses?.get(0)?.profileUrl
                                     ) isOptional true,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("placeId가 공백인 경우") {
+                it("400 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(PLACE_ID_PARAM, " ")
+                    }.andExpect {
+                        status { isBadRequest() }
+                    }.andDo {
+                        createDocument(
+                            "get-my-travel-journals-fail-blank-place-id",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "데이터 개수 (default = 10)" example TEST_DEFAULT_SIZE isOptional true,
+                                LAST_ID_PARAM parameterDescription "마지막 여행 일지 ID" example TEST_TRAVEL_JOURNAL_ID isOptional true,
+                                PLACE_ID_PARAM parameterDescription "공백인 장소 id" example " " isOptional true,
                             ),
                         )
                     }
@@ -1274,12 +1301,14 @@ class TravelJournalControllerTest(
                         TEST_USER_ID,
                         TEST_DEFAULT_SIZE,
                         null,
+                        TEST_PLACE_ID,
                         any<TravelJournalSortType>(),
                     )
                 } returns response
                 it("200 응답한다.") {
                     restDocMockMvc.get(targetUri) {
                         header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(PLACE_ID_PARAM, TEST_PLACE_ID)
                     }.andExpect {
                         status { isOk() }
                     }.andDo {
@@ -1291,6 +1320,7 @@ class TravelJournalControllerTest(
                             queryParameters(
                                 SIZE_PARAM parameterDescription "데이터 개수 (default = 10)" example TEST_DEFAULT_SIZE isOptional true,
                                 LAST_ID_PARAM parameterDescription "마지막 여행 일지 ID" example TEST_TRAVEL_JOURNAL_ID isOptional true,
+                                PLACE_ID_PARAM parameterDescription "장소 아이디" example TEST_PLACE_ID isOptional true,
                             ),
                             responseBody(
                                 "hasNext" type JsonFieldType.BOOLEAN description "다음 페이지 여부" example response.hasNext,
@@ -1314,6 +1344,29 @@ class TravelJournalControllerTest(
                                 "content[].travelCompanionSimpleResponses[].profileUrl" type JsonFieldType.STRING description "여행 친구의 프로필 사진" example (
                                     response.content[0].travelCompanionSimpleResponses?.get(0)?.profileUrl
                                     ) isOptional true,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("placeId가 공백인 경우") {
+                it("400 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(PLACE_ID_PARAM, " ")
+                    }.andExpect {
+                        status { isBadRequest() }
+                    }.andDo {
+                        createDocument(
+                            "get-friend-travel-journals-fail-blank-place-id",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "데이터 개수 (default = 10)" example TEST_DEFAULT_SIZE isOptional true,
+                                LAST_ID_PARAM parameterDescription "마지막 여행 일지 ID" example TEST_TRAVEL_JOURNAL_ID isOptional true,
+                                PLACE_ID_PARAM parameterDescription "공백인 장소 id" example " " isOptional true,
                             ),
                         )
                     }
@@ -1354,12 +1407,14 @@ class TravelJournalControllerTest(
                         TEST_USER_ID,
                         TEST_DEFAULT_SIZE,
                         null,
+                        TEST_PLACE_ID,
                         any<TravelJournalSortType>(),
                     )
                 } returns response
                 it("200 응답한다.") {
                     restDocMockMvc.get(targetUri) {
                         header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(PLACE_ID_PARAM, TEST_PLACE_ID)
                     }.andExpect {
                         status { isOk() }
                     }.andDo {
@@ -1371,6 +1426,7 @@ class TravelJournalControllerTest(
                             queryParameters(
                                 SIZE_PARAM parameterDescription "데이터 개수 (default = 10)" example TEST_DEFAULT_SIZE isOptional true,
                                 LAST_ID_PARAM parameterDescription "마지막 여행 일지 ID" example TEST_TRAVEL_JOURNAL_ID isOptional true,
+                                PLACE_ID_PARAM parameterDescription "장소 아이디" example TEST_PLACE_ID isOptional true,
                             ),
                             responseBody(
                                 "hasNext" type JsonFieldType.BOOLEAN description "다음 페이지 여부" example response.hasNext,
@@ -1394,6 +1450,29 @@ class TravelJournalControllerTest(
                                 "content[].travelCompanionSimpleResponses[].profileUrl" type JsonFieldType.STRING description "여행 친구의 프로필 사진" example (
                                     response.content[0].travelCompanionSimpleResponses?.get(0)?.profileUrl
                                     ) isOptional true,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("placeId가 공백인 경우") {
+                it("400 응답한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        param(PLACE_ID_PARAM, " ")
+                    }.andExpect {
+                        status { isBadRequest() }
+                    }.andDo {
+                        createDocument(
+                            "get-recommend-travel-journals-fail-blank-place-id",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            queryParameters(
+                                SIZE_PARAM parameterDescription "데이터 개수 (default = 10)" example TEST_DEFAULT_SIZE isOptional true,
+                                LAST_ID_PARAM parameterDescription "마지막 여행 일지 ID" example TEST_TRAVEL_JOURNAL_ID isOptional true,
+                                PLACE_ID_PARAM parameterDescription "공백인 장소 id" example " " isOptional true,
                             ),
                         )
                     }

--- a/src/test/kotlin/kr/weit/odya/domain/traveljournal/TravelJournalRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/odya/domain/traveljournal/TravelJournalRepositoryTest.kt
@@ -6,6 +6,7 @@ import kr.weit.odya.domain.follow.Follow
 import kr.weit.odya.domain.follow.FollowRepository
 import kr.weit.odya.domain.user.User
 import kr.weit.odya.domain.user.UserRepository
+import kr.weit.odya.support.TEST_SEARCH_PLACE_ID
 import kr.weit.odya.support.TEST_TRAVEL_JOURNAL_TITLE
 import kr.weit.odya.support.createContentImage
 import kr.weit.odya.support.createOtherUser
@@ -26,8 +27,10 @@ class TravelJournalRepositoryTest(
         lateinit var user: User
         lateinit var otherUser: User
         lateinit var travelJournal: TravelJournal
+        lateinit var mySearchTravelJournal: TravelJournal
         lateinit var otherTravelJournal: TravelJournal
         lateinit var friendTravelJournal: TravelJournal
+        lateinit var friendSearchTravelJournal: TravelJournal
         beforeEach {
             user = userRepository.save(createUser())
             otherUser = userRepository.save(createOtherUser())
@@ -74,11 +77,41 @@ class TravelJournalRepositoryTest(
                         ),
                     ),
                 ),
+                createTravelJournal(
+                    id = 4L,
+                    user = user,
+                    travelCompanions = listOf(createTravelCompanionById(user = otherUser)),
+                    travelJournalContents = listOf(
+                        createTravelJournalContent(
+                            placeId = TEST_SEARCH_PLACE_ID,
+                            travelJournalContentImages = listOf(
+                                createTravelJournalContentImage(contentImage = createContentImage(user = user)),
+                                createTravelJournalContentImage(contentImage = createContentImage(name = "test1.webp", originName = "test1.webp", user = user)),
+                            ),
+                        ),
+                    ),
+                ),
+                createTravelJournal(
+                    id = 5L,
+                    user = otherUser,
+                    title = "friendTravelJournal2",
+                    travelCompanions = listOf(createTravelCompanionById(user = user)),
+                    travelJournalContents = listOf(
+                        createTravelJournalContent(
+                            placeId = TEST_SEARCH_PLACE_ID,
+                            travelJournalContentImages = listOf(
+                                createTravelJournalContentImage(contentImage = createContentImage(user = otherUser)),
+                            ),
+                        ),
+                    ),
+                ),
             )
             val saveTravelJournals = travelJournalRepository.saveAll(travelJournals)
             travelJournal = saveTravelJournals[0]
             otherTravelJournal = saveTravelJournals[1]
             friendTravelJournal = saveTravelJournals[2]
+            mySearchTravelJournal = saveTravelJournals[3]
+            friendSearchTravelJournal = saveTravelJournals[4]
         }
 
         context("여행 일지 조회") {
@@ -91,7 +124,7 @@ class TravelJournalRepositoryTest(
         context("여행 일지 사용자 Id로 조회") {
             expect("유저 ID와 일치하는 여행기록을 조회한다.") {
                 val result = travelJournalRepository.getByUserId(user.id)
-                result.size shouldBe 2
+                result.size shouldBe 3
             }
         }
 
@@ -103,7 +136,7 @@ class TravelJournalRepositoryTest(
                     lastId = null,
                     sortType = TravelJournalSortType.LATEST,
                 )
-                result.size shouldBe 3
+                result.size shouldBe 5
             }
 
             expect("나의 여행 일지 목록을 조회한다.") {
@@ -111,9 +144,22 @@ class TravelJournalRepositoryTest(
                     userId = user.id,
                     size = 10,
                     lastId = null,
+                    placeId = null,
                     sortType = TravelJournalSortType.LATEST,
                 )
-                result.size shouldBe 2
+                result.size shouldBe 3
+            }
+
+            expect("나의 여행일지 중에 장소id에 해당하는 목록을 조회한다") {
+                val result = travelJournalRepository.getMyTravelJournalSliceBy(
+                    userId = user.id,
+                    size = 10,
+                    lastId = null,
+                    placeId = TEST_SEARCH_PLACE_ID,
+                    sortType = TravelJournalSortType.LATEST,
+                )
+                result.size shouldBe 1
+                result[0] shouldBe mySearchTravelJournal
             }
 
             expect("내 친구의 여행 일지 목록을 조회한다.") {
@@ -121,10 +167,23 @@ class TravelJournalRepositoryTest(
                     userId = user.id,
                     size = 10,
                     lastId = null,
+                    placeId = null,
+                    sortType = TravelJournalSortType.LATEST,
+                )
+                result.size shouldBe 2
+                result[0] shouldBe friendSearchTravelJournal
+            }
+
+            expect("내 친구 여행일지 중에 장소id에 해당하는 목록을 조회한다") {
+                val result = travelJournalRepository.getFriendTravelJournalSliceBy(
+                    userId = user.id,
+                    size = 10,
+                    lastId = null,
+                    placeId = TEST_SEARCH_PLACE_ID,
                     sortType = TravelJournalSortType.LATEST,
                 )
                 result.size shouldBe 1
-                result[0] shouldBe friendTravelJournal
+                result[0] shouldBe friendSearchTravelJournal
             }
 
             expect("추천 여행 일지 목록을 조회한다.") {
@@ -132,10 +191,23 @@ class TravelJournalRepositoryTest(
                     user = user,
                     size = 10,
                     lastId = null,
+                    placeId = null,
+                    sortType = TravelJournalSortType.LATEST,
+                )
+                result.size shouldBe 2
+                result[0] shouldBe friendSearchTravelJournal
+            }
+
+            expect("추천 여행일지 중에 장소id에 해당하는 목록을 조회한다") {
+                val result = travelJournalRepository.getRecommendTravelJournalSliceBy(
+                    user = user,
+                    size = 10,
+                    lastId = null,
+                    placeId = TEST_SEARCH_PLACE_ID,
                     sortType = TravelJournalSortType.LATEST,
                 )
                 result.size shouldBe 1
-                result[0] shouldBe friendTravelJournal
+                result[0] shouldBe friendSearchTravelJournal
             }
 
             expect("유저가 태그된 여행일지 목록을 조회한다.") {
@@ -144,7 +216,7 @@ class TravelJournalRepositoryTest(
                     size = 10,
                     lastId = null,
                 )
-                result.size shouldBe 1
+                result.size shouldBe 2
                 result[0] shouldBe friendTravelJournal
             }
         }
@@ -174,7 +246,7 @@ class TravelJournalRepositoryTest(
 
             expect("USER ID와 일치하는 여행 일지 모두 삭제한다.") {
                 travelJournalRepository.deleteAllByUserId(user.id)
-                travelJournalRepository.count() shouldBe 1
+                travelJournalRepository.count() shouldBe 2
             }
         }
     },

--- a/src/test/kotlin/kr/weit/odya/service/CommunityServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/CommunityServiceTest.kt
@@ -314,6 +314,7 @@ class CommunityServiceTest : DescribeSpec(
                         TEST_USER_ID,
                         10,
                         null,
+                        TEST_PLACE_ID,
                         CommunitySortType.LATEST,
                     )
                 } returns createAllCommunities()
@@ -323,7 +324,13 @@ class CommunityServiceTest : DescribeSpec(
                 every { communityLikeRepository.existsByCommunityIdAndUserId(any<Long>(), any<Long>()) } returns true
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
-                        communityService.getCommunities(TEST_USER_ID, 10, null, CommunitySortType.LATEST)
+                        communityService.getCommunities(
+                            TEST_USER_ID,
+                            10,
+                            null,
+                            TEST_PLACE_ID,
+                            CommunitySortType.LATEST,
+                        )
                     }
                 }
             }

--- a/src/test/kotlin/kr/weit/odya/service/TravelJournalServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/TravelJournalServiceTest.kt
@@ -568,6 +568,7 @@ class TravelJournalServiceTest : DescribeSpec(
                         TEST_USER_ID,
                         10,
                         null,
+                        TEST_PLACE_ID,
                         TravelJournalSortType.LATEST,
                     )
                 } returns listOf(TEST_TRAVEL_JOURNAL)
@@ -578,6 +579,7 @@ class TravelJournalServiceTest : DescribeSpec(
                             TEST_USER_ID,
                             10,
                             null,
+                            TEST_PLACE_ID,
                             TravelJournalSortType.LATEST,
                         )
                     }
@@ -592,6 +594,7 @@ class TravelJournalServiceTest : DescribeSpec(
                         TEST_OTHER_USER_ID,
                         10,
                         null,
+                        TEST_PLACE_ID,
                         TravelJournalSortType.LATEST,
                     )
                 } returns listOf(TEST_TRAVEL_JOURNAL)
@@ -602,6 +605,7 @@ class TravelJournalServiceTest : DescribeSpec(
                             TEST_OTHER_USER_ID,
                             10,
                             null,
+                            TEST_PLACE_ID,
                             TravelJournalSortType.LATEST,
                         )
                     }
@@ -618,6 +622,7 @@ class TravelJournalServiceTest : DescribeSpec(
                         otherUser,
                         10,
                         null,
+                        TEST_PLACE_ID,
                         TravelJournalSortType.LATEST,
                     )
                 } returns listOf(TEST_TRAVEL_JOURNAL)
@@ -628,6 +633,7 @@ class TravelJournalServiceTest : DescribeSpec(
                             TEST_OTHER_USER_ID,
                             10,
                             null,
+                            TEST_PLACE_ID,
                             TravelJournalSortType.LATEST,
                         )
                     }

--- a/src/test/kotlin/kr/weit/odya/support/ParamFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/ParamFixtures.kt
@@ -9,6 +9,7 @@ const val SORT_TYPE_PARAM = "sortType"
 const val LAST_ID_PARAM = "lastId"
 const val NICKNAME_PARAM = "nickname"
 const val PHONE_NUMBERS_PARAM = "phoneNumbers"
+const val PLACE_ID_PARAM = "placeId"
 const val TEST_DEFAULT_PAGE = 0
 const val TEST_DEFAULT_SIZE = 10
 const val TEST_PAGE: Int = 1

--- a/src/test/kotlin/kr/weit/odya/support/PlaceReviewFixture.kt
+++ b/src/test/kotlin/kr/weit/odya/support/PlaceReviewFixture.kt
@@ -16,6 +16,7 @@ const val TEST_PLACE_REVIEW_ID = 1L
 const val TEST_INVALID_PLACE_REVIEW_ID = -1L
 const val TEST_NOT_EXIST_PLACE_REVIEW_ID = 5L
 const val TEST_PLACE_ID = "test_place_id"
+const val TEST_SEARCH_PLACE_ID = "test_search_place_id"
 const val TEST_OTHER_PLACE_ID = "test_other_place_id"
 const val TEST_UPDATE_PLACE_ID = "test_update_place_id"
 const val TEST_REVIEW = "test review"


### PR DESCRIPTION
### 개요
- 장소 id를 통해 커뮤니티와 여행일지를 검색해야하는 이슈가 니즈가 있다

### 변경사항
- 커뮤니티 전체 검색 API 파라메터에 placeId 추가
- 내가쓴, 친구의, 추천 여행일지 API 파라메터에 placeId추가

### 관련 지라 및 위키 링크
- [ODYA-211](https://weit.atlassian.net/browse/ODYA-211)

### 리뷰어에게 하고 싶은 말
- 오늘 아침 회의때 나온 이슈 빠르게 처리했습니다~!
