### PR TITLE
ODYA-221 다른 사람 팔로워 조회시 내가 팔로잉 하는지 필드 추가

### DIFF
--- a/src/main/kotlin/kr/weit/odya/controller/FollowController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/FollowController.kt
@@ -74,24 +74,26 @@ class FollowController(
 
     @GetMapping("/{userId}/followings")
     fun getFollowings(
+        @LoginUserId loginUserId: Long,
         @Positive(message = "USER ID는 양수여야 합니다.")
         @PathVariable("userId")
         userId: Long,
         @PageableDefault(page = 0, size = 10) pageable: Pageable,
         @RequestParam(name = "sortType", required = false, defaultValue = "LATEST") sortType: FollowSortType,
     ): ResponseEntity<SliceResponse<FollowUserResponse>> {
-        return ResponseEntity.ok(followService.getSliceFollowings(userId, pageable, sortType))
+        return ResponseEntity.ok(followService.getSliceFollowings(loginUserId, userId, pageable, sortType))
     }
 
     @GetMapping("/{userId}/followers")
     fun getFollowers(
+        @LoginUserId loginUserId: Long,
         @Positive(message = "USER ID는 양수여야 합니다.")
         @PathVariable("userId")
         userId: Long,
         @PageableDefault(page = 0, size = 10) pageable: Pageable,
         @RequestParam(name = "sortType", required = false, defaultValue = "LATEST") sortType: FollowSortType,
     ): ResponseEntity<SliceResponse<FollowUserResponse>> {
-        return ResponseEntity.ok(followService.getSliceFollowers(userId, pageable, sortType))
+        return ResponseEntity.ok(followService.getSliceFollowers(loginUserId, userId, pageable, sortType))
     }
 
     @GetMapping("/followings/search")

--- a/src/main/kotlin/kr/weit/odya/controller/UserController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/UserController.kt
@@ -126,7 +126,7 @@ class UserController(
         @LoginUserId
         userId: Long,
         @Valid
-        @Size(min = 1, max = 10, message = "전화번호는 1개 이상 10개 이하로 입력해주세요.")
+        @Size(min = 1, max = 30, message = "전화번호는 1개 이상 30개 이하로 입력해주세요.")
         @RequestParam("phoneNumbers")
         phoneNumbers: List<SearchPhoneNumberRequest>,
     ): ResponseEntity<List<UserSimpleResponse>> {

--- a/src/main/kotlin/kr/weit/odya/service/dto/FollowDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/service/dto/FollowDtos.kt
@@ -21,8 +21,9 @@ data class FollowUserResponse(
     val userId: Long,
     val nickname: String,
     val profile: FollowProfileResponse,
+    val isFollowing: Boolean,
 ) {
-    constructor(user: User, profileUrl: String) : this(
+    constructor(user: User, profileUrl: String, isFollowing: Boolean) : this(
         user.id,
         user.nickname,
         FollowProfileResponse(
@@ -33,6 +34,7 @@ data class FollowUserResponse(
                 null
             },
         ),
+        isFollowing,
     )
 }
 

--- a/src/test/kotlin/kr/weit/odya/controller/FollowControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/FollowControllerTest.kt
@@ -391,7 +391,7 @@ class FollowControllerTest(
             context("유효한 토큰이면서, 유효한 요청인 경우") {
                 val response = createFollowSlice()
                 every {
-                    followService.getSliceFollowings(TEST_USER_ID, TEST_PAGEABLE, TEST_SORT_TYPE)
+                    followService.getSliceFollowings(TEST_USER_ID, TEST_USER_ID, TEST_PAGEABLE, TEST_SORT_TYPE)
                 } returns response
                 it("200, 팔로잉 목록을 응답한다.") {
                     restDocMockMvc.perform(
@@ -422,6 +422,7 @@ class FollowControllerTest(
                                     "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
                                     "content[].userId" type JsonFieldType.NUMBER description "사용자 ID" example response.content[0].userId,
                                     "content[].nickname" type JsonFieldType.STRING description "사용자 닉네임" example response.content[0].nickname,
+                                    "content[].isFollowing" type JsonFieldType.BOOLEAN description "사용자 팔로잉 여부" example response.content[0].isFollowing,
                                     "content[].profile.profileUrl" type JsonFieldType.STRING description "사용자 프로필 Url" example response.content[0].profile.profileUrl,
                                     "content[].profile.profileColor.colorHex" type JsonFieldType.STRING description "색상 Hex" example response.content[0].profile.profileColor?.colorHex isOptional true,
                                     "content[].profile.profileColor.red" type JsonFieldType.NUMBER description "RGB RED" example response.content[0].profile.profileColor?.red isOptional true,
@@ -435,7 +436,7 @@ class FollowControllerTest(
 
             context("유효한 토큰이면서, 프로필 PreAuthentication Access Url 생성에 실패한 경우") {
                 every {
-                    followService.getSliceFollowings(TEST_USER_ID, TEST_PAGEABLE, TEST_SORT_TYPE)
+                    followService.getSliceFollowings(TEST_USER_ID, TEST_USER_ID, TEST_PAGEABLE, TEST_SORT_TYPE)
                 } throws ObjectStorageException(SOMETHING_ERROR_MESSAGE)
                 it("500 응답한다.") {
                     restDocMockMvc.perform(
@@ -517,7 +518,7 @@ class FollowControllerTest(
             context("유효한 토큰이면서, 유효한 요청인 경우") {
                 val response = createFollowSlice()
                 every {
-                    followService.getSliceFollowers(TEST_USER_ID, TEST_PAGEABLE, TEST_SORT_TYPE)
+                    followService.getSliceFollowers(TEST_USER_ID, TEST_USER_ID, TEST_PAGEABLE, TEST_SORT_TYPE)
                 } returns response
                 it("200, 팔로잉 목록을 응답한다.") {
                     restDocMockMvc.perform(
@@ -548,6 +549,7 @@ class FollowControllerTest(
                                     "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
                                     "content[].userId" type JsonFieldType.NUMBER description "사용자 ID" example response.content[0].userId,
                                     "content[].nickname" type JsonFieldType.STRING description "사용자 닉네임" example response.content[0].nickname,
+                                    "content[].isFollowing" type JsonFieldType.BOOLEAN description "사용자 팔로잉 여부" example response.content[0].isFollowing,
                                     "content[].profile.profileUrl" type JsonFieldType.STRING description "사용자 프로필 Url" example response.content[0].profile.profileUrl,
                                     "content[].profile.profileColor.colorHex" type JsonFieldType.STRING description "색상 Hex" example response.content[0].profile.profileColor?.colorHex isOptional true,
                                     "content[].profile.profileColor.red" type JsonFieldType.NUMBER description "RGB RED" example response.content[0].profile.profileColor?.red isOptional true,
@@ -561,7 +563,7 @@ class FollowControllerTest(
 
             context("유효한 토큰이면서, 프로필 PreAuthentication Access Url 생성에 실패한 경우") {
                 every {
-                    followService.getSliceFollowers(TEST_USER_ID, TEST_PAGEABLE, TEST_SORT_TYPE)
+                    followService.getSliceFollowers(TEST_USER_ID, TEST_USER_ID, TEST_PAGEABLE, TEST_SORT_TYPE)
                 } throws ObjectStorageException(SOMETHING_ERROR_MESSAGE)
                 it("500 응답한다.") {
                     restDocMockMvc.perform(
@@ -667,6 +669,7 @@ class FollowControllerTest(
                                 "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
                                 "content[].userId" type JsonFieldType.NUMBER description "사용자 ID" example content.userId,
                                 "content[].nickname" type JsonFieldType.STRING description "사용자 닉네임" example content.nickname,
+                                "content[].isFollowing" type JsonFieldType.BOOLEAN description "사용자 팔로잉 여부" example content.isFollowing,
                                 "content[].profile.profileUrl" type JsonFieldType.STRING description "사용자 프로필 Url" example content.profile.profileUrl,
                                 "content[].profile.profileColor.colorHex" type JsonFieldType.STRING description "색상 Hex" example content.profile.profileColor?.colorHex isOptional true,
                                 "content[].profile.profileColor.red" type JsonFieldType.NUMBER description "RGB RED" example content.profile.profileColor?.red isOptional true,
@@ -833,6 +836,7 @@ class FollowControllerTest(
                                 "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
                                 "content[].userId" type JsonFieldType.NUMBER description "사용자 ID" example content.userId,
                                 "content[].nickname" type JsonFieldType.STRING description "사용자 닉네임" example content.nickname,
+                                "content[].isFollowing" type JsonFieldType.BOOLEAN description "사용자 팔로잉 여부" example content.isFollowing,
                                 "content[].profile.profileUrl" type JsonFieldType.STRING description "사용자 프로필 Url" example content.profile.profileUrl,
                                 "content[].profile.profileColor.colorHex" type JsonFieldType.STRING description "색상 Hex" example content.profile.profileColor?.colorHex isOptional true,
                                 "content[].profile.profileColor.red" type JsonFieldType.NUMBER description "RGB RED" example content.profile.profileColor?.red isOptional true,
@@ -972,6 +976,7 @@ class FollowControllerTest(
                                 "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
                                 "content[].userId" type JsonFieldType.NUMBER description "사용자 ID" example content.userId,
                                 "content[].nickname" type JsonFieldType.STRING description "사용자 닉네임" example content.nickname,
+                                "content[].isFollowing" type JsonFieldType.BOOLEAN description "사용자 팔로잉 여부" example content.isFollowing,
                                 "content[].profile.profileUrl" type JsonFieldType.STRING description "사용자 프로필 Url" example content.profile.profileUrl,
                                 "content[].profile.profileColor.colorHex" type JsonFieldType.STRING description "색상 Hex" example content.profile.profileColor?.colorHex isOptional true,
                                 "content[].profile.profileColor.red" type JsonFieldType.NUMBER description "RGB RED" example content.profile.profileColor?.red isOptional true,
@@ -1102,6 +1107,7 @@ class FollowControllerTest(
                                     "count" type JsonFieldType.NUMBER description "방문한 친구 수" example response.count,
                                     "followings[].userId" type JsonFieldType.NUMBER description "사용자 ID" example following.userId,
                                     "followings[].nickname" type JsonFieldType.STRING description "사용자 닉네임" example following.nickname,
+                                    "followings[].isFollowing" type JsonFieldType.BOOLEAN description "사용자 팔로잉 여부" example following.isFollowing,
                                     "followings[].profile.profileUrl" type JsonFieldType.STRING description "사용자 프로필 Url" example following.profile.profileUrl,
                                     "followings[].profile.profileColor.colorHex" type JsonFieldType.STRING description "색상 Hex" example following.profile.profileColor?.colorHex isOptional true,
                                     "followings[].profile.profileColor.red" type JsonFieldType.NUMBER description "RGB RED" example following.profile.profileColor?.red isOptional true,

--- a/src/test/kotlin/kr/weit/odya/controller/UserControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/UserControllerTest.kt
@@ -1262,11 +1262,11 @@ class UserControllerTest(
                 }
             }
 
-            context("유효한 토큰이면서, 검색할 전화번호를 10개를 넘개 보낸 경우") {
+            context("유효한 토큰이면서, 검색할 전화번호를 30개를 넘개 보낸 경우") {
                 it("400 응답한다.") {
                     restDocMockMvc.get(targetUri) {
                         header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                        repeat(11) {
+                        repeat(31) {
                             param(PHONE_NUMBERS_PARAM, TEST_PHONE_NUMBER)
                         }
                     }.andExpect {

--- a/src/test/kotlin/kr/weit/odya/service/FollowServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/FollowServiceTest.kt
@@ -133,10 +133,11 @@ class FollowServiceTest : DescribeSpec(
                         TEST_DEFAULT_SORT_TYPE,
                     )
                 } returns createFollowList()
+                every { followRepository.findFollowingIdsByFollowerId(TEST_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
                 every { fileService.getPreAuthenticatedObjectUrl(TEST_DEFAULT_PROFILE_PNG) } returns TEST_PROFILE_URL
                 it("SliceResponse<FollowUserResponse>를 반환한다.") {
                     val response =
-                        followService.getSliceFollowings(TEST_USER_ID, TEST_DEFAULT_PAGEABLE, TEST_DEFAULT_SORT_TYPE)
+                        followService.getSliceFollowings(TEST_USER_ID, TEST_USER_ID, TEST_DEFAULT_PAGEABLE, TEST_DEFAULT_SORT_TYPE)
                     response.content[0].userId shouldBe TEST_OTHER_USER_ID
                 }
             }
@@ -152,9 +153,10 @@ class FollowServiceTest : DescribeSpec(
                 every { fileService.getPreAuthenticatedObjectUrl(TEST_DEFAULT_PROFILE_PNG) } throws ObjectStorageException(
                     SOMETHING_ERROR_MESSAGE,
                 )
+                every { followRepository.findFollowingIdsByFollowerId(TEST_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
                 it("[ObjectStorageException] 반환한다.") {
                     shouldThrow<ObjectStorageException> {
-                        followService.getSliceFollowings(TEST_USER_ID, TEST_DEFAULT_PAGEABLE, TEST_DEFAULT_SORT_TYPE)
+                        followService.getSliceFollowings(TEST_USER_ID, TEST_USER_ID, TEST_DEFAULT_PAGEABLE, TEST_DEFAULT_SORT_TYPE)
                     }
                 }
             }
@@ -169,10 +171,11 @@ class FollowServiceTest : DescribeSpec(
                         TEST_DEFAULT_SORT_TYPE,
                     )
                 } returns createFollowList()
+                every { followRepository.findFollowingIdsByFollowerId(TEST_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
                 every { fileService.getPreAuthenticatedObjectUrl(TEST_DEFAULT_PROFILE_PNG) } returns TEST_PROFILE_URL
                 it("SliceResponse<FollowUserResponse>를 반환한다.") {
                     val response =
-                        followService.getSliceFollowers(TEST_USER_ID, TEST_DEFAULT_PAGEABLE, TEST_DEFAULT_SORT_TYPE)
+                        followService.getSliceFollowers(TEST_USER_ID, TEST_USER_ID, TEST_DEFAULT_PAGEABLE, TEST_DEFAULT_SORT_TYPE)
                     response.content[0].userId shouldBe TEST_USER_ID
                 }
             }
@@ -185,12 +188,13 @@ class FollowServiceTest : DescribeSpec(
                         TEST_DEFAULT_SORT_TYPE,
                     )
                 } returns createFollowList()
+                every { followRepository.findFollowingIdsByFollowerId(TEST_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
                 every { fileService.getPreAuthenticatedObjectUrl(TEST_DEFAULT_PROFILE_PNG) } throws ObjectStorageException(
                     SOMETHING_ERROR_MESSAGE,
                 )
                 it("[ObjectStorageException] 반환한다.") {
                     shouldThrow<ObjectStorageException> {
-                        followService.getSliceFollowers(TEST_USER_ID, TEST_DEFAULT_PAGEABLE, TEST_DEFAULT_SORT_TYPE)
+                        followService.getSliceFollowers(TEST_USER_ID, TEST_USER_ID, TEST_DEFAULT_PAGEABLE, TEST_DEFAULT_SORT_TYPE)
                     }
                 }
             }
@@ -232,6 +236,7 @@ class FollowServiceTest : DescribeSpec(
                 every { usersDocumentRepository.getByNickname(TEST_NICKNAME) } returns listOf(createUsersDocument(user))
                 every { followRepository.getByFollowingIdAndFollowerIdIn(any(), any(), any(), any()) } returns listOf(createFollow(following = user))
                 every { fileService.getPreAuthenticatedObjectUrl(TEST_DEFAULT_PROFILE_PNG) } returns TEST_PROFILE_URL
+                every { followRepository.findFollowingIdsByFollowerId(TEST_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
                 it("유저를 조회 한다") {
                     shouldNotThrowAny { followService.searchByFollowerNickname(TEST_USER_ID, TEST_NICKNAME, TEST_DEFAULT_SIZE, null) }
                 }

--- a/src/test/kotlin/kr/weit/odya/support/FollowFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/FollowFixtures.kt
@@ -24,7 +24,8 @@ fun createFollow(follower: User = createUser(), following: User = createOtherUse
 fun createFollowUserResponse(
     userId: Long = TEST_USER_ID,
     nickname: String = TEST_NICKNAME,
-) = FollowUserResponse(userId, nickname, createFollowProfileResponse())
+    isFollowing: Boolean = true,
+) = FollowUserResponse(userId, nickname, createFollowProfileResponse(), isFollowing)
 
 fun createFollowList(): List<Follow> = listOf(createFollow())
 


### PR DESCRIPTION
### 개요
- 다른 사람의 팔로잉/팔로워 검색할때 내가 해당 유저를 팔로잉 하는지 확인하는 필드가 필요하다
- 전화번호로 유저 검색할때 10개 제한은 적다 늘려야 한다

### 변경사항
- 팔로잉 API에 팔로잉 여부 추가
- 1회당 전화번호 검색 제한 30개로 상향

### 관련 지라 및 위키 링크
- [ODYA-221](https://weit.atlassian.net/browse/ODYA-221)

### 리뷰어에게 하고 싶은 말
- IOS 개발자님들이 제보 해주셔서 빠르게 처리했습니다! ㅋㅋㅋ
