### PR TITLE
ODYA-223 Spring 취약점 해결

### DIFF
--- a/Dockerfile-cache
+++ b/Dockerfile-cache
@@ -6,5 +6,5 @@ WORKDIR /app
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY
 
-RUN ./gradlew assemble && \
+RUN ./gradlew assemble -x test -x asciidoctor && \
     rm -rf /app

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
     implementation("com.oracle.database.security:osdt_core:19.8.0.0")
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
 
-    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-core:10.2.0")
 
     implementation("com.google.firebase:firebase-admin:9.1.1")
     implementation("com.google.maps:google-maps-services:2.2.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
     implementation("com.oracle.database.security:osdt_core:19.8.0.0")
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
 
-    implementation("org.flywaydb:flyway-core:10.2.0")
+    implementation("org.flywaydb:flyway-core:9.16.3")
 
     implementation("com.google.firebase:firebase-admin:9.1.1")
     implementation("com.google.maps:google-maps-services:2.2.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "3.1.0"
+    id("org.springframework.boot") version "3.1.6"
     id("io.spring.dependency-management") version "1.1.0"
     id("org.jlleitschuh.gradle.ktlint") version "11.2.0"
     id("org.asciidoctor.jvm.convert") version "3.3.2"
@@ -78,7 +78,7 @@ dependencies {
     }
 
     implementation(platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.1"))
-    implementation("io.awspring.cloud:spring-cloud-aws-starter-parameter-store")
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-parameter-store:3.1.0")
     implementation("org.springframework.cloud:spring-cloud-starter-bootstrap:4.0.3")
 
     asciidoctorExt("org.springframework.restdocs:spring-restdocs-asciidoctor")


### PR DESCRIPTION
### 개요
- Spring boot 3.1.0~3.1.5의 DOS 취약점이 발견되었다

### 변경사항
- 취약점이 해결된 3.1.6으로 업그레이드

### 관련 지라 및 위키 링크
- [ODYA-223](https://weit.atlassian.net/browse/ODYA-223)
- [CVE-2023-34055](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-34055)

### 리뷰어에게 하고 싶은 말
- 저번주에 요거 회사에서 제가 패치했었는데 여기도 해두면 좋을것 같아서 작업해봤습니다~! ㅋㅋㅋ
