### PR TITLE
ODYA-228 여행일지의 visibility 변경 API추가

### DIFF
--- a/src/docs/asciidoc/travelJournal.adoc
+++ b/src/docs/asciidoc/travelJournal.adoc
@@ -282,59 +282,86 @@ operation::travel-journal-controller-test/travel-journal-content-update-fail-not
 
 operation::travel-journal-controller-test/travel-journal-content-update-fail-invalid-token[snippets='http-request,request-headers,path-parameters,request-parts,http-response']
 
-[[여행일지삭제-API]]
-== *10. 여행 일지 삭제 API*
+[[여행일지-공개범위-수정-API]]
+== *10. 여행 일지 공개 범위 수정 API*
 
 === *10-1 성공*
 
+operation::travel-journal-controller-test/travel-journals-visibility-update-success[snippets='http-request,request-headers,path-parameters,request-body,http-response']
+
+=== *10-2 실패 - 유효하지 않은 여행일지 id인 경우*
+
+operation::travel-journal-controller-test/travel-journals-visibility-update-fail-invalid-travel-journal-id[snippets='http-request,request-headers,path-parameters,request-body,http-response']
+
+=== *10-3 실패 - 존재하지 않는 여행일지 id인 경우*
+
+operation::travel-journal-controller-test/travel-journals-visibility-update-fail-not-found-travel-journal[snippets='http-request,request-headers,path-parameters,request-body,http-response']
+
+=== *10-4 실패 - 커뮤니티에 연결된 여행일지를 비공개로 바꾸려고 한 경우*
+
+operation::travel-journal-controller-test/travel-journals-visibility-update-fail-community-connected[snippets='http-request,request-headers,path-parameters,request-body,http-response']
+
+=== *10-5 실패 - 작성자와 요청자가 다른 경우*
+
+operation::travel-journal-controller-test/travel-journals-visibility-update-fail-not-same-user[snippets='http-request,request-headers,path-parameters,request-body,http-response']
+
+=== *10-6 실패 - 유효하지 않은 토큰일 경우*
+
+operation::travel-journal-controller-test/travel-journals-visibility-update-fail-invalid-token[snippets='http-request,request-headers,path-parameters,request-body,http-response']
+
+[[여행일지삭제-API]]
+== *11. 여행 일지 삭제 API*
+
+=== *11-1 성공*
+
 operation::travel-journal-controller-test/travel-journals-delete-success[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *10-2 실패 - 작성자와 요청자가 다른 경우*
+=== *11-2 실패 - 작성자와 요청자가 다른 경우*
 
 operation::travel-journal-controller-test/travel-journals-delete-fail-not-same-user[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *10-3 실패 - 유효하지 않은 토큰일 경우*
+=== *11-3 실패 - 유효하지 않은 토큰일 경우*
 
 operation::travel-journal-controller-test/travel-journals-delete-fail-invalid-token[snippets='http-request,request-headers,path-parameters,http-response']
 
 [[여행일지콘텐츠삭제-API]]
-== *11. 여행 일지 콘텐츠 삭제 API*
+== *12. 여행 일지 콘텐츠 삭제 API*
 
-=== *11-1 성공*
+=== *12-1 성공*
 
 operation::travel-journal-controller-test/travel-journal-content-delete-success[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *11-2 실패 - 작성자와 요청자가 다른 경우*
+=== *12-2 실패 - 작성자와 요청자가 다른 경우*
 
 operation::travel-journal-controller-test/travel-journal-content-delete-fail-not-same-user[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *11-3 실패 - 여행 일지 콘텐츠 아이디와 일치하는 여행 일지 콘텐츠가 없는 경우*
+=== *12-3 실패 - 여행 일지 콘텐츠 아이디와 일치하는 여행 일지 콘텐츠가 없는 경우*
 
 operation::travel-journal-controller-test/travel-journal-content-delete-fail-not-found[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *11-4 실패 - 유효하지 않은 토큰일 경우*
+=== *12-4 실패 - 유효하지 않은 토큰일 경우*
 
 operation::travel-journal-controller-test/travel-journal-content-delete-fail-invalid-token[snippets='http-request,request-headers,path-parameters,http-response']
 
 [[여행일지같이간친구삭제-API]]
-== *12. 여행 일지 같이 간 친구 삭제 API*
+== *13. 여행 일지 같이 간 친구 삭제 API*
 
-=== *12-1 성공*
+=== *13-1 성공*
 
 operation::travel-journal-controller-test/travel-journal-remove-travel-companion-success[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *12-2 실패 - 양수가 아닌 여행 일지 ID가 들어온 경우*
+=== *13-2 실패 - 양수가 아닌 여행 일지 ID가 들어온 경우*
 
 operation::travel-journal-controller-test/travel-journal-remove-travel-companion-fail-invalid-id[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *12-3 실패 - 해당 여행일지의 같이 간 친구를 처리할 권한이 없는 경우*
+=== *13-3 실패 - 해당 여행일지의 같이 간 친구를 처리할 권한이 없는 경우*
 
 operation::travel-journal-controller-test/travel-journal-remove-travel-companion-fail-no-permission[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *12-4 실패 - 존재하지 않는 유저ID가 들어온 경우*
+=== *13-4 실패 - 존재하지 않는 유저ID가 들어온 경우*
 
 operation::travel-journal-controller-test/travel-journal-remove-travel-companion-fail-not-found[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *12-5 실패 - 유효하지 않은 토큰일 경우*
+=== *13-5 실패 - 유효하지 않은 토큰일 경우*
 
 operation::travel-journal-controller-test/travel-journal-remove-travel-companion-fail-invalid-token[snippets='http-request,request-headers,path-parameters,http-response']

--- a/src/main/kotlin/kr/weit/odya/controller/TravelJournalController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/TravelJournalController.kt
@@ -13,15 +13,18 @@ import kr.weit.odya.service.dto.TravelJournalRequest
 import kr.weit.odya.service.dto.TravelJournalResponse
 import kr.weit.odya.service.dto.TravelJournalSummaryResponse
 import kr.weit.odya.service.dto.TravelJournalUpdateRequest
+import kr.weit.odya.service.dto.TravelJournalVisibilityUpdateRequest
 import kr.weit.odya.support.validator.NullOrNotBlank
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
@@ -213,6 +216,20 @@ class TravelJournalController(private val travelJournalService: TravelJournalSer
             imageNamePairs,
             placeDetailsMap,
         )
+        return ResponseEntity.noContent().build()
+    }
+
+    @PatchMapping("/{travelJournalId}/visibility")
+    fun updateTravelJournalVisibility(
+        @Positive(message = "travelJournalId는 0보다 커야합니다.")
+        @PathVariable("travelJournalId")
+        travelJournalId: Long,
+        @LoginUserId userId: Long,
+        @Valid
+        @RequestBody
+        travelJournalVisibilityUpdateRequest: TravelJournalVisibilityUpdateRequest,
+    ): ResponseEntity<Void> {
+        travelJournalService.updateTravelJournalVisibility(travelJournalId, userId, travelJournalVisibilityUpdateRequest)
         return ResponseEntity.noContent().build()
     }
 

--- a/src/main/kotlin/kr/weit/odya/domain/community/CommunityRepository.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/community/CommunityRepository.kt
@@ -61,6 +61,8 @@ interface CommunityRepository : JpaRepository<Community, Long>, CustomCommunityR
     fun deleteAllByUserId(userId: Long)
 
     fun findAllByUserId(userId: Long): List<Community>
+
+    fun existsByTravelJournalId(travelJournalId: Long): Boolean
 }
 
 interface CustomCommunityRepository {

--- a/src/main/kotlin/kr/weit/odya/service/dto/TravelJournalDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/service/dto/TravelJournalDtos.kt
@@ -215,6 +215,11 @@ data class TravelJournalContentUpdateRequest(
     )
 }
 
+data class TravelJournalVisibilityUpdateRequest(
+    @field:NotNull(message = "여행 일지 공개 여부는 필수 입력값입니다.")
+    val visibility: TravelJournalVisibility,
+)
+
 data class TravelJournalSummaryResponse(
     val travelJournalId: Long,
     val title: String,

--- a/src/test/kotlin/kr/weit/odya/controller/TravelJournalControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/TravelJournalControllerTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import jakarta.ws.rs.ForbiddenException
 import kr.weit.odya.domain.traveljournal.TravelJournalSortType
+import kr.weit.odya.domain.traveljournal.TravelJournalVisibility
 import kr.weit.odya.service.ObjectStorageException
 import kr.weit.odya.service.TravelJournalService
 import kr.weit.odya.service.dto.TravelJournalContentUpdateRequest
@@ -66,11 +67,13 @@ import kr.weit.odya.support.createTravelJournalRequestByContentSize
 import kr.weit.odya.support.createTravelJournalRequestFile
 import kr.weit.odya.support.createTravelJournalResponse
 import kr.weit.odya.support.createTravelJournalUpdateRequest
+import kr.weit.odya.support.createTravelJournalVisibilityUpdateRequest
 import kr.weit.odya.support.createUser
 import kr.weit.odya.support.test.BaseTests.UnitControllerTestEnvironment
 import kr.weit.odya.support.test.ControllerTestHelper
 import kr.weit.odya.support.test.RestDocsHelper
 import kr.weit.odya.support.test.RestDocsHelper.Companion.createDocument
+import kr.weit.odya.support.test.RestDocsHelper.Companion.requestBody
 import kr.weit.odya.support.test.RestDocsHelper.Companion.responseBody
 import kr.weit.odya.support.test.example
 import kr.weit.odya.support.test.files
@@ -83,6 +86,7 @@ import kr.weit.odya.support.test.type
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
 import org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
@@ -2593,6 +2597,190 @@ class TravelJournalControllerTest(
                                         "updateContentImageNames(List<String>): 여행 일지 콘텐츠 이미지 이름(Nullable)\n " +
                                         "deleteContentImageIds(List<Long>): 삭제할 여행 일지 콘텐츠 이미지 아이디(Nullable)\n ",
                                     "travel-journal-content-image-update" requestPartDescription "추가할 여행 일지 콘텐츠 이미지" isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+        }
+
+        describe("PATCH /api/v1/travel-journals/{travelJournalId}/visibility") {
+            val targetUri = "/api/v1/travel-journals/{travelJournalId}/visibility"
+            context("유효한 요청이 왔을 경우") {
+                val request = createTravelJournalVisibilityUpdateRequest()
+                every { travelJournalService.updateTravelJournalVisibility(TEST_TRAVEL_JOURNAL_ID, TEST_USER_ID, request) } just runs
+                it("204 응답한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .patch(targetUri, TEST_TRAVEL_JOURNAL_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                ControllerTestHelper.jsonContent(
+                                    request,
+                                ),
+                            ),
+                    )
+                        .andExpect(status().isNoContent)
+                        .andDo(
+                            RestDocsHelper.createPathDocument(
+                                "travel-journals-visibility-update-success",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "travelJournalId" pathDescription "공개 여부를 수정할 여행 일지의 아이디" example TEST_TRAVEL_JOURNAL_ID,
+                                ),
+                                requestBody(
+                                    "visibility" type JsonFieldType.STRING description "여행 일지 공개 범위" example request.visibility,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효하지 않은 여행일지 id인 경우") {
+                val request = createTravelJournalVisibilityUpdateRequest()
+                it("400 응답한다") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .patch(targetUri, TEST_INVALID_TRAVEL_JOURNAL_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                ControllerTestHelper.jsonContent(
+                                    request,
+                                ),
+                            ),
+                    )
+                        .andExpect(status().isBadRequest)
+                        .andDo(
+                            RestDocsHelper.createPathDocument(
+                                "travel-journals-visibility-update-fail-invalid-travel-journal-id",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "travelJournalId" pathDescription "유효하지 않은 여행 일지의 아이디" example TEST_INVALID_TRAVEL_JOURNAL_ID,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("존재하지 않는 여행일지 id인 경우") {
+                val request = createTravelJournalVisibilityUpdateRequest()
+                every { travelJournalService.updateTravelJournalVisibility(TEST_TRAVEL_JOURNAL_ID, TEST_USER_ID, request) } throws NoSuchElementException("해당 여행 일지($TEST_TRAVEL_JOURNAL_ID)가 존재하지 않습니다.")
+                it("404 응답한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .patch(targetUri, TEST_TRAVEL_JOURNAL_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                ControllerTestHelper.jsonContent(
+                                    request,
+                                ),
+                            ),
+                    )
+                        .andExpect(status().isNotFound)
+                        .andDo(
+                            RestDocsHelper.createPathDocument(
+                                "travel-journals-visibility-update-fail-not-found-travel-journal",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "travelJournalId" pathDescription "존재하지 않는 여행일지 id",
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("커뮤니티에 연결된 여행일지를 비공개로 바꾸려고 한 경우") {
+                val request = createTravelJournalVisibilityUpdateRequest(TravelJournalVisibility.PRIVATE)
+                every { travelJournalService.updateTravelJournalVisibility(TEST_TRAVEL_JOURNAL_ID, TEST_USER_ID, request) } throws IllegalStateException("여행 일지가 커뮤니티에 등록되어 있어 비공개로 변경할 수 없습니다.")
+                it("400 응답한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .patch(targetUri, TEST_TRAVEL_JOURNAL_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                ControllerTestHelper.jsonContent(
+                                    request,
+                                ),
+                            ),
+                    )
+                        .andExpect(status().isBadRequest)
+                        .andDo(
+                            RestDocsHelper.createPathDocument(
+                                "travel-journals-visibility-update-fail-community-connected",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "travelJournalId" pathDescription "공개 여부를 수정할 여행 일지의 아이디" example TEST_TRAVEL_JOURNAL_ID,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("작성자와 요청자가 다른 경우") {
+                val request = createTravelJournalVisibilityUpdateRequest()
+                every { travelJournalService.updateTravelJournalVisibility(TEST_TRAVEL_JOURNAL_ID, TEST_USER_ID, request) } throws ForbiddenException("요청 사용자($TEST_USER_ID)는 해당 요청을 처리할 권한이 없습니다.")
+                it("403 응답한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .patch(targetUri, TEST_TRAVEL_JOURNAL_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                ControllerTestHelper.jsonContent(
+                                    request,
+                                ),
+                            ),
+                    )
+                        .andExpect(status().isForbidden)
+                        .andDo(
+                            RestDocsHelper.createPathDocument(
+                                "travel-journals-visibility-update-fail-not-same-user",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "작성자가 아닌 사용자 ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "travelJournalId" pathDescription "공개 여부를 수정할 여행 일지의 아이디" example TEST_TRAVEL_JOURNAL_ID,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효하지 않은 토큰인 경우") {
+                val request = createTravelJournalVisibilityUpdateRequest()
+                it("401 응답한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .patch(targetUri, TEST_TRAVEL_JOURNAL_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                ControllerTestHelper.jsonContent(
+                                    request,
+                                ),
+                            ),
+                    )
+                        .andExpect(status().isUnauthorized)
+                        .andDo(
+                            RestDocsHelper.createPathDocument(
+                                "travel-journals-visibility-update-fail-invalid-token",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "travelJournalId" pathDescription "공개 여부를 수정할 여행 일지의 아이디" example TEST_TRAVEL_JOURNAL_ID,
                                 ),
                             ),
                         )

--- a/src/test/kotlin/kr/weit/odya/domain/community/CommunityRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/odya/domain/community/CommunityRepositoryTest.kt
@@ -132,6 +132,17 @@ class CommunityRepositoryTest(
             }
         }
 
+        context("여행일지가 연결된 커뮤니티가 있는지 조회") {
+            expect("여행일지가 연결된 커뮤니티가 없다") {
+                val result = communityRepository.existsByTravelJournalId(travelJournal2.id + 1)
+                result shouldBe false
+            }
+            expect("여행일지가 연결된 커뮤니티가 있다") {
+                val result = communityRepository.existsByTravelJournalId(travelJournal2.id)
+                result shouldBe true
+            }
+        }
+
         context("커뮤니티 목록 조회") {
             expect("공개 커뮤니티와 나의 친구들 커뮤니티 목록을 조회한다.") {
                 val result =

--- a/src/test/kotlin/kr/weit/odya/support/TravelJournalFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/TravelJournalFixtures.kt
@@ -23,6 +23,7 @@ import kr.weit.odya.service.dto.TravelJournalResponse
 import kr.weit.odya.service.dto.TravelJournalSimpleResponse
 import kr.weit.odya.service.dto.TravelJournalSummaryResponse
 import kr.weit.odya.service.dto.TravelJournalUpdateRequest
+import kr.weit.odya.service.dto.TravelJournalVisibilityUpdateRequest
 import kr.weit.odya.service.dto.UserSimpleResponse
 import org.springframework.mock.web.MockMultipartFile
 import java.io.InputStream
@@ -121,6 +122,12 @@ fun createOtherTravelJournalContentRequest() = createTravelJournalContentRequest
     content = TEST_OTHER_TRAVEL_JOURNAL_CONTENT,
     travelDate = TEST_OTHER_TRAVEL_DATE,
     contentImageNames = listOf(TEST_OTHER_IMAGE_FILE_WEBP),
+)
+
+fun createTravelJournalVisibilityUpdateRequest(
+    visibility: TravelJournalVisibility = TravelJournalVisibility.FRIEND_ONLY,
+) = TravelJournalVisibilityUpdateRequest(
+    visibility = visibility,
 )
 
 fun createImageMap(


### PR DESCRIPTION
### 개요
- 여행일지는 visibility만 수정하는 플로우가 있다

### 변경사항
- 여행일지의 공개 범위 수정 API 추가 

### 관련 지라 및 위키 링크
- [ODYA-228](https://weit.atlassian.net/browse/ODYA-228)

### 리뷰어에게 하고 싶은 말
- 정아님이 제보해주셔서 빠르게 적용해봤습니다~!
