### PR TITLE
ODYA-229 내가 태그된 여행일지 오류 수정

### DIFF
--- a/src/main/kotlin/kr/weit/odya/domain/traveljournal/TravelJournalRepository.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/traveljournal/TravelJournalRepository.kt
@@ -205,17 +205,11 @@ class CustomTravelJournalRepositoryImpl(private val queryFactory: QueryFactory) 
     }
 
     override fun findTaggedTravelJournalSliceBy(user: User, size: Int, lastId: Long?): List<TravelJournal> = queryFactory.listQuery {
-        select(entity(TravelJournal::class))
-        from(entity(TravelJournal::class))
+        getTravelJournalSliceBaseQuery(lastId, TravelJournalSortType.LATEST, size, null)
         associate(
             entity(TravelJournal::class),
             entity(TravelCompanion::class),
             Relation<TravelJournal, TravelCompanion>("mutableTravelCompanions"),
-        )
-        associate(
-            entity(TravelJournal::class),
-            entity(TravelJournalInformation::class),
-            on(TravelJournal::travelJournalInformation),
         )
         where(
             and(

--- a/src/test/kotlin/kr/weit/odya/domain/traveljournal/TravelJournalRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/odya/domain/traveljournal/TravelJournalRepositoryTest.kt
@@ -31,6 +31,7 @@ class TravelJournalRepositoryTest(
         lateinit var otherTravelJournal: TravelJournal
         lateinit var friendTravelJournal: TravelJournal
         lateinit var friendSearchTravelJournal: TravelJournal
+        lateinit var friendLastTravelJournal: TravelJournal
         beforeEach {
             user = userRepository.save(createUser())
             otherUser = userRepository.save(createOtherUser())
@@ -105,6 +106,19 @@ class TravelJournalRepositoryTest(
                         ),
                     ),
                 ),
+                createTravelJournal(
+                    id = 6L,
+                    user = otherUser,
+                    title = "friendTravelJournal3",
+                    travelCompanions = listOf(createTravelCompanionById(user = user)),
+                    travelJournalContents = listOf(
+                        createTravelJournalContent(
+                            travelJournalContentImages = listOf(
+                                createTravelJournalContentImage(contentImage = createContentImage(user = otherUser)),
+                            ),
+                        ),
+                    ),
+                ),
             )
             val saveTravelJournals = travelJournalRepository.saveAll(travelJournals)
             travelJournal = saveTravelJournals[0]
@@ -112,6 +126,7 @@ class TravelJournalRepositoryTest(
             friendTravelJournal = saveTravelJournals[2]
             mySearchTravelJournal = saveTravelJournals[3]
             friendSearchTravelJournal = saveTravelJournals[4]
+            friendLastTravelJournal = saveTravelJournals[5]
         }
 
         context("여행 일지 조회") {
@@ -136,7 +151,7 @@ class TravelJournalRepositoryTest(
                     lastId = null,
                     sortType = TravelJournalSortType.LATEST,
                 )
-                result.size shouldBe 5
+                result.size shouldBe 6
             }
 
             expect("나의 여행 일지 목록을 조회한다.") {
@@ -170,8 +185,8 @@ class TravelJournalRepositoryTest(
                     placeId = null,
                     sortType = TravelJournalSortType.LATEST,
                 )
-                result.size shouldBe 2
-                result[0] shouldBe friendSearchTravelJournal
+                result.size shouldBe 3
+                result[0] shouldBe friendLastTravelJournal
             }
 
             expect("내 친구 여행일지 중에 장소id에 해당하는 목록을 조회한다") {
@@ -194,8 +209,8 @@ class TravelJournalRepositoryTest(
                     placeId = null,
                     sortType = TravelJournalSortType.LATEST,
                 )
-                result.size shouldBe 2
-                result[0] shouldBe friendSearchTravelJournal
+                result.size shouldBe 3
+                result[0] shouldBe friendLastTravelJournal
             }
 
             expect("추천 여행일지 중에 장소id에 해당하는 목록을 조회한다") {
@@ -216,8 +231,18 @@ class TravelJournalRepositoryTest(
                     size = 10,
                     lastId = null,
                 )
+                result.size shouldBe 3
+                result[0] shouldBe friendLastTravelJournal
+            }
+
+            expect("유저가 태그된 여행일지 목록을 조회할때 사이즈를 지정한다.") {
+                val result = travelJournalRepository.getTaggedTravelJournalSliceBy(
+                    user = user,
+                    size = 1,
+                    lastId = null,
+                )
                 result.size shouldBe 2
-                result[0] shouldBe friendTravelJournal
+                result[0] shouldBe friendLastTravelJournal
             }
         }
 
@@ -246,7 +271,7 @@ class TravelJournalRepositoryTest(
 
             expect("USER ID와 일치하는 여행 일지 모두 삭제한다.") {
                 travelJournalRepository.deleteAllByUserId(user.id)
-                travelJournalRepository.count() shouldBe 2
+                travelJournalRepository.count() shouldBe 3
             }
         }
     },


### PR DESCRIPTION
### 개요
- 내가 태그된 여행일지 조회시 페이지네이션이 안되고 소팅도 안되고있었다

### 변경사항
- 내가 태그된 여행일지 조회 쿼리에 slice쿼리 추가

### 관련 지라 및 위키 링크
- [ODYA-229](https://weit.atlassian.net/browse/ODYA-229)

### 리뷰어에게 하고 싶은 말
- 요번 작업은 희오님이 제보해주셨고 서버 잘못이 아닌줄 알고 큰소리 쳤는데 서버 문제 맞았네요 ㅋㅋㅋ...
- 심지어 제가 예전에 잘못작업했던 부분입니다 ㅋ큐ㅠㅠ
