### PR TITLE
ODYA-237 유저통계 API에 인생샷 개수 추가

### DIFF
--- a/src/main/kotlin/kr/weit/odya/domain/contentimage/ContentImageRepository.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/contentimage/ContentImageRepository.kt
@@ -27,6 +27,8 @@ fun ContentImageRepository.getImageByRectangle(
 
 interface ContentImageRepository : JpaRepository<ContentImage, Long>, CustomContentImageRepository {
     fun deleteAllByUserId(userId: Long)
+
+    fun countByUserIdAndIsLifeShotIsTrue(userId: Long): Int
 }
 
 interface CustomContentImageRepository {

--- a/src/main/kotlin/kr/weit/odya/service/UserService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/UserService.kt
@@ -2,6 +2,7 @@ package kr.weit.odya.service
 
 import kr.weit.odya.domain.community.CommunityRepository
 import kr.weit.odya.domain.community.getAllByUserId
+import kr.weit.odya.domain.contentimage.ContentImageRepository
 import kr.weit.odya.domain.follow.FollowRepository
 import kr.weit.odya.domain.follow.getFollowingIds
 import kr.weit.odya.domain.traveljournal.TravelJournalRepository
@@ -41,6 +42,7 @@ class UserService(
     private val followRepository: FollowRepository,
     private val travelJournalRepository: TravelJournalRepository,
     private val communityRepository: CommunityRepository,
+    private val contentImageRepository: ContentImageRepository,
 ) {
     fun getEmailByIdToken(idToken: String) = firebaseTokenHelper.getEmail(idToken)
 
@@ -123,12 +125,14 @@ class UserService(
             travelJournal.travelJournalContents.count { content -> content.placeId != null }
         }
         val communityLikeCount = communityRepository.getAllByUserId(userId).sumOf { it.likeCount }
+        val lifeShotCount = contentImageRepository.countByUserIdAndIsLifeShotIsTrue(userId)
         return UserStatisticsResponse(
             travelJournalCount = travelJournals.size,
             travelPlaceCount = travelPlaceCount,
             followingsCount = followingsCount,
             followersCount = followersCount,
             odyaCount = communityLikeCount,
+            lifeShotCount = lifeShotCount,
         )
     }
 

--- a/src/main/kotlin/kr/weit/odya/service/dto/UsersDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/service/dto/UsersDtos.kt
@@ -116,6 +116,7 @@ data class UserStatisticsResponse(
     val followingsCount: Int,
     val followersCount: Int,
     val odyaCount: Int,
+    val lifeShotCount: Int,
 )
 
 data class SearchPhoneNumberRequest(

--- a/src/test/kotlin/kr/weit/odya/controller/UserControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/UserControllerTest.kt
@@ -975,6 +975,7 @@ class UserControllerTest(
                                     "followingsCount" type JsonFieldType.NUMBER description "팔로잉 수" example response.followingsCount,
                                     "followersCount" type JsonFieldType.NUMBER description "팔로워 수" example response.followersCount,
                                     "odyaCount" type JsonFieldType.NUMBER description "총 오댜수" example response.odyaCount,
+                                    "lifeShotCount" type JsonFieldType.NUMBER description "총 인생샷 수" example response.lifeShotCount,
                                 ),
                             ),
                         )

--- a/src/test/kotlin/kr/weit/odya/service/UserServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/UserServiceTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import kr.weit.odya.domain.community.CommunityRepository
 import kr.weit.odya.domain.community.getAllByUserId
+import kr.weit.odya.domain.contentimage.ContentImageRepository
 import kr.weit.odya.domain.follow.FollowRepository
 import kr.weit.odya.domain.follow.getFollowingIds
 import kr.weit.odya.domain.traveljournal.TravelJournalRepository
@@ -37,6 +38,7 @@ import kr.weit.odya.support.TEST_FOLLOWER_COUNT
 import kr.weit.odya.support.TEST_FOLLOWING_COUNT
 import kr.weit.odya.support.TEST_ID_TOKEN
 import kr.weit.odya.support.TEST_INVALID_PROFILE_ORIGINAL_NAME
+import kr.weit.odya.support.TEST_LIFE_SHOT_COUNT
 import kr.weit.odya.support.TEST_MOCK_PROFILE_NAME
 import kr.weit.odya.support.TEST_NICKNAME
 import kr.weit.odya.support.TEST_OTHER_USER_ID
@@ -66,6 +68,7 @@ class UserServiceTest : DescribeSpec(
         val followRepository = mockk<FollowRepository>()
         val travelJournalRepository = mockk<TravelJournalRepository>()
         val communityRepository = mockk<CommunityRepository>()
+        val contentImageRepository = mockk<ContentImageRepository>()
         val userService =
             UserService(
                 userRepository,
@@ -76,6 +79,7 @@ class UserServiceTest : DescribeSpec(
                 followRepository,
                 travelJournalRepository,
                 communityRepository,
+                contentImageRepository,
             )
 
         describe("getInformation") {
@@ -368,6 +372,7 @@ class UserServiceTest : DescribeSpec(
                 every { communityRepository.getAllByUserId(TEST_USER_ID) } returns listOf(createCommunity()).onEach { community ->
                     repeat(2) { community.increaseLikeCount() }
                 }
+                every { contentImageRepository.countByUserIdAndIsLifeShotIsTrue(TEST_USER_ID) } returns TEST_LIFE_SHOT_COUNT
                 it("[FollowCountsResponse] 반환한다.") {
                     val response = userService.getStatistics(TEST_USER_ID)
                     response shouldBe createUserStatisticsResponse()

--- a/src/test/kotlin/kr/weit/odya/support/CommunityFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/CommunityFixtures.kt
@@ -43,6 +43,7 @@ const val TEST_COMMUNITY_UPDATE_MOCK_FILE_NAME = "update-community-content-image
 const val MIM_COMMUNITY_CONTENT_IMAGE_COUNT = 1
 const val MAX_COMMUNITY_CONTENT_IMAGE_COUNT = 15
 const val TEST_COMMUNITY_LIKE_COUNT = 2
+const val TEST_LIFE_SHOT_COUNT = 10
 const val TEST_IS_USER_LIKED = false
 val TEST_CREATED_DATE: LocalDateTime = LocalDateTime.parse("2021-01-01T00:00:00")
 

--- a/src/test/kotlin/kr/weit/odya/support/UserFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/UserFixtures.kt
@@ -144,6 +144,7 @@ fun createUserStatisticsResponse() = UserStatisticsResponse(
     followingsCount = TEST_FOLLOWING_COUNT,
     followersCount = TEST_FOLLOWER_COUNT,
     odyaCount = TEST_COMMUNITY_LIKE_COUNT,
+    lifeShotCount = TEST_LIFE_SHOT_COUNT,
 )
 
 fun createLifeShotRequest(placeName: String? = TEST_PLACE_NAME) = LifeShotRequest(


### PR DESCRIPTION
### 개요
- 유저의 인생샷 개수로 클라가 알아야 한다

### 변경사항
- 유저 통계 API 응답에 인생샷 개수 필드 추가

### 관련 지라 및 위키 링크
- [ODYA-237](https://weit.atlassian.net/browse/ODYA-237)

### 리뷰어에게 하고 싶은 말
- 지혜님이 제보해주셔서 쓱삭 했습니다 ㅋㅋㅋ
