### PR TITLE
ODYA-247 북마크 여부가 잘못내려가는 현상 수정

### DIFF
--- a/src/main/kotlin/kr/weit/odya/service/TravelJournalBookmarkService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/TravelJournalBookmarkService.kt
@@ -82,7 +82,7 @@ class TravelJournalBookmarkService(
     ): SliceResponse<TravelJournalBookmarkSummaryResponse> {
         val user = userRepository.getByUserId(userId)
         val followingIdList = followRepository.getFollowingIds(loginUser)
-        val bookmarkTravelJournalIdList = travelJournalBookmarkRepository.getTravelJournalIds(userId)
+        val bookmarkTravelJournalIdList = travelJournalBookmarkRepository.getTravelJournalIds(loginUser)
         val journalBookmarkResponses =
             travelJournalBookmarkRepository.getSliceByOther(size, lastId, sortType, user, loginUser).map { bookmark ->
                 val profileUrl = fileService.getPreAuthenticatedObjectUrl(bookmark.user.profile.profileName)

--- a/src/test/kotlin/kr/weit/odya/service/TravelJournalBookmarkServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/TravelJournalBookmarkServiceTest.kt
@@ -162,7 +162,7 @@ class TravelJournalBookmarkServiceTest : DescribeSpec(
                 } returns listOf(createTravelJournalBookmark())
                 every { fileService.getPreAuthenticatedObjectUrl(any<String>()) } returns TEST_FILE_AUTHENTICATED_URL
                 every { followRepository.findFollowingIdsByFollowerId(TEST_OTHER_USER_ID) } returns listOf(TEST_USER_ID)
-                every { travelJournalBookmarkRepository.getTravelJournalIds(TEST_USER_ID) } returns listOf(TEST_TRAVEL_JOURNAL_ID)
+                every { travelJournalBookmarkRepository.getTravelJournalIds(TEST_OTHER_USER_ID) } returns listOf(TEST_TRAVEL_JOURNAL_ID)
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
                         travelJournalBookmarkService.getOtherTravelJournalBookmarks(


### PR DESCRIPTION
### 개요
- 타인의 북마크 여행일지 조회시 로그인한 유저의 북마크 여부가 아니라 타인의 북마크 여부가 내려가고 있었다

### 변경사항
- 로그인한 유저의 북마크 여부를 검색해서 북마크 여부 확인

### 관련 지라 및 위키 링크
- [ODYA-247](https://weit.atlassian.net/browse/ODYA-247)

### 리뷰어에게 하고 싶은 말
- 희오님이 제보해주셔서 알았는데 이런 버그가 있었네요 ㅋㅋ큐ㅠ
