### PR TITLE
ODYA-248 타인의 관심장소 수 조회

### DIFF
--- a/src/docs/asciidoc/favoritePlace.adoc
+++ b/src/docs/asciidoc/favoritePlace.adoc
@@ -73,56 +73,71 @@ operation::favorite-place-controller-test/favorite-place-count-success[snippets=
 
 operation::favorite-place-controller-test/favorite-place-count-failed-invalid-token[snippets='http-request,request-headers,http-response']
 
-[[관심장소리스트조회-API]]
-== *5. 관심 장소 리스트 조회 API*
+[[타인의관심장소수조회-API]]
+== *5. 타인의 관심 장소 수 조회 API*
 
 === *5-1 성공*
 
+operation::favorite-place-controller-test/other-favorite-place-count-success[snippets='http-request,request-headers,http-response']
+
+=== *5-2 실패 - 양수가 아닌 USERID*
+
+operation::favorite-place-controller-test/other-favorite-place-count-failed-invalid-favorite-place-id[snippets='http-request,request-headers,http-response']
+
+=== *5-3 실패 - 유효하지 않은 토큰*
+
+operation::favorite-place-controller-test/other-favorite-place-count-failed-invalid-token[snippets='http-request,request-headers,http-response']
+
+[[관심장소리스트조회-API]]
+== *6. 관심 장소 리스트 조회 API*
+
+=== *6-1 성공*
+
 operation::favorite-place-controller-test/favorite-place-list-success[snippets='http-request,request-headers,query-parameters,http-response']
 
-=== *5-2 성공*
+=== *6-2 성공*
 
 operation::favorite-place-controller-test/favorite-place-list-request-param-null-success[snippets='http-request,request-headers,query-parameters,http-response']
 
-=== *5-3 실패 - 양수가 아닌 사이즈*
+=== *6-3 실패 - 양수가 아닌 사이즈*
 
 operation::favorite-place-controller-test/favorite-place-list-failed-invalid-size[snippets='http-request,request-headers,query-parameters,http-response']
 
-=== *5-4 실패 - 정의되지않은 정렬기준*
+=== *6-4 실패 - 정의되지않은 정렬기준*
 
 operation::favorite-place-controller-test/favorite-place-list-failed-invalid-sort-type[snippets='http-request,request-headers,query-parameters,http-response']
 
-=== *5-5 실패 - 양수가 아닌 마지막 ID*
+=== *6-5 실패 - 양수가 아닌 마지막 ID*
 
 operation::favorite-place-controller-test/favorite-place-list-failed-invalid-last-id[snippets='http-request,request-headers,query-parameters,http-response']
 
-=== *5-6 실패 - 유효하지 않은 토큰*
+=== *6-6 실패 - 유효하지 않은 토큰*
 
 operation::favorite-place-controller-test/favorite-place-list-failed-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']
 
 [[타인의관심장소리스트조회-API]]
-== *6. 타인의 관심 장소 리스트 조회 API*
+== *7. 타인의 관심 장소 리스트 조회 API*
 
-=== *6-1 성공*
+=== *7-1 성공*
 
 operation::favorite-place-controller-test/other-favorite-place-list-success[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
-=== *6-2 실패 - 양수가 아닌 userId*
+=== *7-2 실패 - 양수가 아닌 userId*
 
 operation::favorite-place-controller-test/other-favorite-place-list-failed-invalid-id[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
-=== *6-3 실패 - 양수가 아닌 사이즈*
+=== *7-3 실패 - 양수가 아닌 사이즈*
 
 operation::favorite-place-controller-test/other-favorite-place-list-failed-invalid-size[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
-=== *6-4 실패 - 정의되지않은 정렬기준*
+=== *7-4 실패 - 정의되지않은 정렬기준*
 
 operation::favorite-place-controller-test/other-favorite-place-list-failed-invalid-sort-type[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
-=== *6-5 실패 - 양수가 아닌 마지막 ID*
+=== *7-5 실패 - 양수가 아닌 마지막 ID*
 
 operation::favorite-place-controller-test/other-favorite-place-list-failed-invalid-last-id[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
-=== *6-6 실패 - 유효하지 않은 토큰*
+=== *7-6 실패 - 유효하지 않은 토큰*
 
 operation::favorite-place-controller-test/other-favorite-place-list-failed-invalid-token[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']

--- a/src/main/kotlin/kr/weit/odya/controller/FavoritePlaceController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/FavoritePlaceController.kt
@@ -69,6 +69,15 @@ class FavoritePlaceController(private val favoritePlaceService: FavoritePlaceSer
         return ResponseEntity.ok(favoritePlaceService.getFavoritePlaceCount(userId))
     }
 
+    @GetMapping("/counts/{userId}")
+    fun getFavoriteOtherPlaceCount(
+        @PathVariable("userId")
+        @Positive(message = "USER ID는 양수여야 합니다.")
+        userId: Long,
+    ): ResponseEntity<Int> {
+        return ResponseEntity.ok(favoritePlaceService.getFavoritePlaceCount(userId))
+    }
+
     @GetMapping("/list")
     fun getFavoritePlaceList(
         @LoginUserId

--- a/src/test/kotlin/kr/weit/odya/controller/FavoritePlaceControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/FavoritePlaceControllerTest.kt
@@ -63,797 +63,781 @@ class FavoritePlaceControllerTest(
     @MockkBean private val favoritePlaceService: FavoritePlaceService,
     private val context: WebApplicationContext,
 ) : DescribeSpec(
-    {
-        val restDocumentation = ManualRestDocumentation()
-        val restDocMockMvc = RestDocsHelper.generateRestDocMockMvc(context, restDocumentation)
+        {
+            val restDocumentation = ManualRestDocumentation()
+            val restDocMockMvc = RestDocsHelper.generateRestDocMockMvc(context, restDocumentation)
 
-        beforeEach {
-            restDocumentation.beforeTest(javaClass, it.name.testName)
-        }
-
-        describe("POST /api/v1/favorite-places") {
-            val targetUri = "/api/v1/favorite-places"
-            context("유효한 요청 데이터가 전달되면") {
-                val request = createFavoritePlaceRequest()
-                every { favoritePlaceService.createFavoritePlace(TEST_USER_ID, createFavoritePlaceRequest()) } just Runs
-                it("201를 반환한다.") {
-                    restDocMockMvc.post(targetUri) {
-                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                        jsonContent(request)
-                    }.andExpect {
-                        status { isCreated() }
-                    }.andDo {
-                        createDocument(
-                            "favorite-place-create-success",
-                            requestHeaders(
-                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                            ),
-                            requestBody(
-                                "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
-                            ),
-                        )
-                    }
-                }
+            beforeEach {
+                restDocumentation.beforeTest(javaClass, it.name.testName)
             }
 
-            context("유효한 토큰이면서 장소 ID가 빈 문자열이면") {
-                val request = createFavoritePlaceRequest().copy(placeId = " ")
-                it("400를 반환한다.") {
-                    restDocMockMvc.post(targetUri) {
-                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                        jsonContent(request)
-                    }.andExpect {
-                        status { isBadRequest() }
-                    }.andDo {
-                        createDocument(
-                            "favorite-place-create-failed-empty-place-id",
-                            requestHeaders(
-                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                            ),
-                            requestBody(
-                                "placeId" type JsonFieldType.STRING description "공백인 장소 ID" example """ """,
-                            ),
-                        )
-                    }
-                }
-            }
-
-            context("가입되어 있지 않은 USERID이 주어지는 경우") {
-                val request = createFavoritePlaceRequest()
-                it("401를 반환한다.") {
-                    restDocMockMvc.post(targetUri) {
-                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN)
-                        jsonContent(request)
-                    }.andExpect {
-                        status { isUnauthorized() }
-                    }.andDo {
-                        createDocument(
-                            "favorite-place-create-failed-not-exist-user-id",
-                            requestHeaders(
-                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                            ),
-                            requestBody(
-                                "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
-                            ),
-                        )
-                    }
-                }
-            }
-
-            context("유효한 토큰이지만, 이미 관심 장소인 경우") {
-                val request = createFavoritePlaceRequest()
-                every {
-                    favoritePlaceService.createFavoritePlace(TEST_USER_ID, createFavoritePlaceRequest())
-                } throws ExistResourceException(EXIST_FAVORITE_PLACE_ERROR_MESSAGE)
-                it("409를 반환한다.") {
-                    restDocMockMvc.post(targetUri) {
-                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                        jsonContent(request)
-                    }.andExpect {
-                        status { isConflict() }
-                    }.andDo {
-                        createDocument(
-                            "favorite-place-create-failed-already-exist-favorite-place",
-                            requestHeaders(
-                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                            ),
-                            requestBody(
-                                "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
-                            ),
-                        )
-                    }
-                }
-            }
-
-            context("유효하지 않은 토큰이 전달되면") {
-                val request = createFavoritePlaceRequest()
-                it("401를 반환한다.") {
-                    restDocMockMvc.post(targetUri) {
-                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
-                        jsonContent(request)
-                    }.andExpect {
-                        status { isUnauthorized() }
-                    }.andDo {
-                        createDocument(
-                            "favorite-place-create-failed-invalid-token",
-                            requestHeaders(
-                                HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                            ),
-                            requestBody(
-                                "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
-                            ),
-                        )
-                    }
-                }
-            }
-        }
-
-        describe("DELETE /api/v1/favorite-places/{id}") {
-            val targetUri = "/api/v1/favorite-places/{id}"
-            context("유효한 요청 데이터가 전달되면") {
-                every { favoritePlaceService.deleteFavoritePlace(TEST_USER_ID, TEST_FAVORITE_PLACE_ID) } just Runs
-                it("204를 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .delete(targetUri, TEST_FAVORITE_PLACE_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                    ).andExpect(status().isNoContent)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-delete-success",
-                                pathParameters(
-                                    "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
-                                ),
+            describe("POST /api/v1/favorite-places") {
+                val targetUri = "/api/v1/favorite-places"
+                context("유효한 요청 데이터가 전달되면") {
+                    val request = createFavoritePlaceRequest()
+                    every { favoritePlaceService.createFavoritePlace(TEST_USER_ID, createFavoritePlaceRequest()) } just Runs
+                    it("201를 반환한다.") {
+                        restDocMockMvc.post(targetUri) {
+                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            jsonContent(request)
+                        }.andExpect {
+                            status { isCreated() }
+                        }.andDo {
+                            createDocument(
+                                "favorite-place-create-success",
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                            ),
-                        )
-                }
-            }
-
-            context("양수가 아닌 관심 장소 ID인 경우") {
-                it("400를 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .delete(targetUri, TEST_INVALID_FAVORITE_PLACE_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                    ).andExpect(status().isBadRequest)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-delete-failed-invalid-favorite-place-id",
-                                pathParameters(
-                                    "id" pathDescription "양수가 아닌 관심 장소 ID" example TEST_INVALID_FAVORITE_PLACE_ID,
+                                requestBody(
+                                    "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
                                 ),
+                            )
+                        }
+                    }
+                }
+
+                context("유효한 토큰이면서 장소 ID가 빈 문자열이면") {
+                    val request = createFavoritePlaceRequest().copy(placeId = " ")
+                    it("400를 반환한다.") {
+                        restDocMockMvc.post(targetUri) {
+                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            jsonContent(request)
+                        }.andExpect {
+                            status { isBadRequest() }
+                        }.andDo {
+                            createDocument(
+                                "favorite-place-create-failed-empty-place-id",
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                            ),
-                        )
-                }
-            }
-
-            context("가입되어 있지 않은 USERID이 주어지는 경우") {
-                it("401를 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .delete(targetUri, TEST_FAVORITE_PLACE_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN),
-                    ).andExpect(status().isUnauthorized)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-delete-failed-not-exist-user-id",
-                                pathParameters(
-                                    "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
+                                requestBody(
+                                    "placeId" type JsonFieldType.STRING description "공백인 장소 ID" example """ """,
                                 ),
+                            )
+                        }
+                    }
+                }
+
+                context("가입되어 있지 않은 USERID이 주어지는 경우") {
+                    val request = createFavoritePlaceRequest()
+                    it("401를 반환한다.") {
+                        restDocMockMvc.post(targetUri) {
+                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN)
+                            jsonContent(request)
+                        }.andExpect {
+                            status { isUnauthorized() }
+                        }.andDo {
+                            createDocument(
+                                "favorite-place-create-failed-not-exist-user-id",
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                            ),
-                        )
-                }
-            }
-
-            context("유효한 토큰이지만, 관심 장소가 아닌 경우") {
-                every {
-                    favoritePlaceService.deleteFavoritePlace(TEST_USER_ID, TEST_EXIST_FAVORITE_PLACE_ID)
-                } throws NoSuchElementException(NOT_FOUND_FAVORITE_PLACE_ERROR_MESSAGE)
-                it("404를 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .delete(targetUri, TEST_EXIST_FAVORITE_PLACE_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                    ).andExpect(status().isNotFound)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-delete-failed-not-exist-favorite-place-id",
-                                pathParameters(
-                                    "id" pathDescription "존재하지 않는 관심 장소 ID" example TEST_EXIST_FAVORITE_PLACE_ID,
+                                requestBody(
+                                    "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
                                 ),
+                            )
+                        }
+                    }
+                }
+
+                context("유효한 토큰이지만, 이미 관심 장소인 경우") {
+                    val request = createFavoritePlaceRequest()
+                    every {
+                        favoritePlaceService.createFavoritePlace(TEST_USER_ID, createFavoritePlaceRequest())
+                    } throws ExistResourceException(EXIST_FAVORITE_PLACE_ERROR_MESSAGE)
+                    it("409를 반환한다.") {
+                        restDocMockMvc.post(targetUri) {
+                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            jsonContent(request)
+                        }.andExpect {
+                            status { isConflict() }
+                        }.andDo {
+                            createDocument(
+                                "favorite-place-create-failed-already-exist-favorite-place",
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                            ),
-                        )
-                }
-            }
-
-            context("유효하지 않은 토큰이 전달되면") {
-                it("401를 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .delete(targetUri, TEST_FAVORITE_PLACE_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
-                    ).andExpect(status().isUnauthorized)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-delete-failed-invalid-token",
-                                pathParameters(
-                                    "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
+                                requestBody(
+                                    "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
                                 ),
+                            )
+                        }
+                    }
+                }
+
+                context("유효하지 않은 토큰이 전달되면") {
+                    val request = createFavoritePlaceRequest()
+                    it("401를 반환한다.") {
+                        restDocMockMvc.post(targetUri) {
+                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                            jsonContent(request)
+                        }.andExpect {
+                            status { isUnauthorized() }
+                        }.andDo {
+                            createDocument(
+                                "favorite-place-create-failed-invalid-token",
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
                                 ),
-                            ),
-                        )
-                }
-            }
-        }
-
-        describe("GET /api/v1/favorite-places/{placeId}") {
-            val targetUri = "/api/v1/favorite-places/{placeId}"
-            context("유효한 요청 데이터가 전달되면") {
-                every { favoritePlaceService.getFavoritePlace(TEST_USER_ID, TEST_PLACE_ID) } returns true
-                it("200를 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri, TEST_PLACE_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                    ).andExpect(status().isOk)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-check-success",
-                                pathParameters(
-                                    "placeId" pathDescription "장소 ID" example TEST_PLACE_ID,
+                                requestBody(
+                                    "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
                                 ),
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                ),
-                            ),
-                        )
-                }
-            }
-
-            context("placeId가 공백인 경우") {
-                it("400를 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri, " ")
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                    ).andExpect(status().isBadRequest)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-check-failed-empty-place-id",
-                                pathParameters(
-                                    "placeId" pathDescription "공백인 장소 ID" example " ",
-                                ),
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                ),
-                            ),
-                        )
-                }
-            }
-
-            context("유효하지 않은 토큰 전달되면") {
-                it("401를 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri, TEST_PLACE_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
-                    ).andExpect(status().isUnauthorized)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-check-failed-invalid-token",
-                                pathParameters(
-                                    "placeId" pathDescription "장소 ID" example TEST_PLACE_ID,
-                                ),
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                                ),
-                            ),
-                        )
-                }
-            }
-        }
-
-        describe("GET /api/v1/favorite-places/counts") {
-            val targetUri = "/api/v1/favorite-places/counts"
-            context("유효한 USERID가 전달되면") {
-                every { favoritePlaceService.getFavoritePlaceCount(TEST_USER_ID) } returns TEST_FAVORITE_PLACE_COUNT
-                it("관심장소 수를 출력한다.") {
-                    restDocMockMvc.get(targetUri) {
-                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                    }.andExpect {
-                        status {  isOk() }
-                    }.andDo {
-                        createDocument(
-                            "favorite-place-count-success",
-                            requestHeaders(
-                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                            ),
-                        )
+                            )
+                        }
                     }
                 }
             }
 
-            context("유효하지않은 토큰이 전달되면") {
-                it("401을 출력한다.") {
-                    restDocMockMvc.get(targetUri) {
-                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
-                    }.andExpect {
-                        status { isUnauthorized() }
-                    }.andDo {
-                        createDocument(
-                            "favorite-place-count-failed-invalid-token",
-                            requestHeaders(
-                                HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                            ),
-                        )
+            describe("DELETE /api/v1/favorite-places/{id}") {
+                val targetUri = "/api/v1/favorite-places/{id}"
+                context("유효한 요청 데이터가 전달되면") {
+                    every { favoritePlaceService.deleteFavoritePlace(TEST_USER_ID, TEST_FAVORITE_PLACE_ID) } just Runs
+                    it("204를 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .delete(targetUri, TEST_FAVORITE_PLACE_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                        ).andExpect(status().isNoContent)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-delete-success",
+                                    pathParameters(
+                                        "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
+                                    ),
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("양수가 아닌 관심 장소 ID인 경우") {
+                    it("400를 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .delete(targetUri, TEST_INVALID_FAVORITE_PLACE_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                        ).andExpect(status().isBadRequest)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-delete-failed-invalid-favorite-place-id",
+                                    pathParameters(
+                                        "id" pathDescription "양수가 아닌 관심 장소 ID" example TEST_INVALID_FAVORITE_PLACE_ID,
+                                    ),
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("가입되어 있지 않은 USERID이 주어지는 경우") {
+                    it("401를 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .delete(targetUri, TEST_FAVORITE_PLACE_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN),
+                        ).andExpect(status().isUnauthorized)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-delete-failed-not-exist-user-id",
+                                    pathParameters(
+                                        "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
+                                    ),
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("유효한 토큰이지만, 관심 장소가 아닌 경우") {
+                    every {
+                        favoritePlaceService.deleteFavoritePlace(TEST_USER_ID, TEST_EXIST_FAVORITE_PLACE_ID)
+                    } throws NoSuchElementException(NOT_FOUND_FAVORITE_PLACE_ERROR_MESSAGE)
+                    it("404를 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .delete(targetUri, TEST_EXIST_FAVORITE_PLACE_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                        ).andExpect(status().isNotFound)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-delete-failed-not-exist-favorite-place-id",
+                                    pathParameters(
+                                        "id" pathDescription "존재하지 않는 관심 장소 ID" example TEST_EXIST_FAVORITE_PLACE_ID,
+                                    ),
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("유효하지 않은 토큰이 전달되면") {
+                    it("401를 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .delete(targetUri, TEST_FAVORITE_PLACE_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
+                        ).andExpect(status().isUnauthorized)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-delete-failed-invalid-token",
+                                    pathParameters(
+                                        "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
+                                    ),
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                                    ),
+                                ),
+                            )
                     }
                 }
             }
-        }
 
-        describe("GET /api/v1/favorite-places/counts/{userId}") {
-            val targetUri = "/api/v1/favorite-places/counts/{userId}"
-            context("유효한 USERID가 전달되면") {
-                every { favoritePlaceService.getFavoritePlaceCount(TEST_OTHER_USER_ID) } returns TEST_FAVORITE_PLACE_COUNT
-                it("관심장소 수를 출력한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri, TEST_OTHER_USER_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                    )
-                        .andExpect(status().isOk)
-                        .andDo(
-                            createPathDocument(
-                                "other-favorite-place-count-success",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+            describe("GET /api/v1/favorite-places/{placeId}") {
+                val targetUri = "/api/v1/favorite-places/{placeId}"
+                context("유효한 요청 데이터가 전달되면") {
+                    every { favoritePlaceService.getFavoritePlace(TEST_USER_ID, TEST_PLACE_ID) } returns true
+                    it("200를 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri, TEST_PLACE_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                        ).andExpect(status().isOk)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-check-success",
+                                    pathParameters(
+                                        "placeId" pathDescription "장소 ID" example TEST_PLACE_ID,
+                                    ),
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
                                 ),
-                                pathParameters(
-                                    "userId" pathDescription "조회할 USER ID" example TEST_OTHER_USER_ID,
+                            )
+                    }
+                }
+
+                context("placeId가 공백인 경우") {
+                    it("400를 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri, " ")
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                        ).andExpect(status().isBadRequest)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-check-failed-empty-place-id",
+                                    pathParameters(
+                                        "placeId" pathDescription "공백인 장소 ID" example " ",
+                                    ),
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
                                 ),
-                            ),
-                        )
+                            )
+                    }
+                }
+
+                context("유효하지 않은 토큰 전달되면") {
+                    it("401를 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri, TEST_PLACE_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
+                        ).andExpect(status().isUnauthorized)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-check-failed-invalid-token",
+                                    pathParameters(
+                                        "placeId" pathDescription "장소 ID" example TEST_PLACE_ID,
+                                    ),
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                                    ),
+                                ),
+                            )
+                    }
                 }
             }
 
-            context("양수가 아닌 USERID가 전달되면") {
-                it("400을 출력한다") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri, TEST_INVALID_USER_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                    )
-                        .andExpect(status().isBadRequest)
-                        .andDo(
-                            createPathDocument(
-                                "other-favorite-place-count-failed-invalid-favorite-place-id",
+            describe("GET /api/v1/favorite-places/counts") {
+                val targetUri = "/api/v1/favorite-places/counts"
+                context("유효한 USERID가 전달되면") {
+                    every { favoritePlaceService.getFavoritePlaceCount(TEST_USER_ID) } returns TEST_FAVORITE_PLACE_COUNT
+                    it("관심장소 수를 출력한다.") {
+                        restDocMockMvc.get(targetUri) {
+                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        }.andExpect {
+                            status { isOk() }
+                        }.andDo {
+                            createDocument(
+                                "favorite-place-count-success",
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                                pathParameters(
-                                    "userId" pathDescription "양수가 아닌 USER ID" example TEST_INVALID_USER_ID,
-                                ),
-                            ),
-                        )
+                            )
+                        }
+                    }
                 }
-            }
 
-            context("유효하지않은 토큰이 전달되면") {
-                it("401을 출력한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri, TEST_OTHER_USER_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
-                    )
-                        .andExpect(status().isUnauthorized())
-                        .andDo(
-                            createPathDocument(
-                                "other-favorite-place-count-failed-invalid-token",
+                context("유효하지않은 토큰이 전달되면") {
+                    it("401을 출력한다.") {
+                        restDocMockMvc.get(targetUri) {
+                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                        }.andExpect {
+                            status { isUnauthorized() }
+                        }.andDo {
+                            createDocument(
+                                "favorite-place-count-failed-invalid-token",
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
                                 ),
-                                pathParameters(
-                                    "userId" pathDescription "조회할 USER ID" example TEST_OTHER_USER_ID,
-                                ),
-                            ),
-                        )
-                }
-            }
-        }
-
-        describe("GET /api/v1/favorite-places/list") {
-            val targetUri = "/api/v1/favorite-places/list"
-            context("유효한 USERID와 size,sortType,lastId가 전달되면") {
-                val response = createSliceFavoritePlaceResponse()
-                val content = response.content[0]
-                every {
-                    favoritePlaceService.getMyFavoritePlaceList(
-                        TEST_USER_ID,
-                        TEST_SIZE,
-                        TEST_FAVORITE_PLACE_SORT_TYPE,
-                        TEST_LAST_ID,
-                    )
-                } returns createSliceFavoritePlaceResponse()
-                it("관심장소 수를 출력한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            .param(SIZE_PARAM, TEST_SIZE.toString())
-                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                    ).andExpect(status().isOk)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-list-success",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                ),
-                                queryParameters(
-                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                ),
-                                responseBody(
-                                    "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
-                                    "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
-                                    "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
-                                    "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
-                                    "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
-                                ),
-                            ),
-                        )
+                            )
+                        }
+                    }
                 }
             }
 
-            context("유효한 USERID만 전달되면") {
-                val response = createSliceFavoritePlaceResponse()
-                val content = response.content[0]
-                every {
-                    favoritePlaceService.getMyFavoritePlaceList(
-                        TEST_USER_ID,
-                        TEST_DEFAULT_SIZE,
-                        TEST_FAVORITE_PLACE_SORT_TYPE,
-                        null,
-                    )
-                } returns createSliceFavoritePlaceResponse()
-                it("관심장소 수를 출력한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                    ).andExpect(status().isOk)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-list-request-param-null-success",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                ),
-                                queryParameters(
-                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example "null" isOptional true,
-                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example "null" isOptional true,
-                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example "null" isOptional true,
-                                ),
-                                responseBody(
-                                    "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
-                                    "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
-                                    "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
-                                    "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
-                                    "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
-                                ),
-                            ),
+            describe("GET /api/v1/favorite-places/counts/{userId}") {
+                val targetUri = "/api/v1/favorite-places/counts/{userId}"
+                context("유효한 USERID가 전달되면") {
+                    every { favoritePlaceService.getFavoritePlaceCount(TEST_OTHER_USER_ID) } returns TEST_FAVORITE_PLACE_COUNT
+                    it("관심장소 수를 출력한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri, TEST_OTHER_USER_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
                         )
+                            .andExpect(status().isOk)
+                            .andDo(
+                                createPathDocument(
+                                    "other-favorite-place-count-success",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                    pathParameters(
+                                        "userId" pathDescription "조회할 USER ID" example TEST_OTHER_USER_ID,
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("양수가 아닌 USERID가 전달되면") {
+                    it("400을 출력한다") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri, TEST_INVALID_USER_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                        )
+                            .andExpect(status().isBadRequest)
+                            .andDo(
+                                createPathDocument(
+                                    "other-favorite-place-count-failed-invalid-favorite-place-id",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                    pathParameters(
+                                        "userId" pathDescription "양수가 아닌 USER ID" example TEST_INVALID_USER_ID,
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("유효하지않은 토큰이 전달되면") {
+                    it("401을 출력한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri, TEST_OTHER_USER_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
+                        )
+                            .andExpect(status().isUnauthorized())
+                            .andDo(
+                                createPathDocument(
+                                    "other-favorite-place-count-failed-invalid-token",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                                    ),
+                                    pathParameters(
+                                        "userId" pathDescription "조회할 USER ID" example TEST_OTHER_USER_ID,
+                                    ),
+                                ),
+                            )
+                    }
                 }
             }
 
-            context("유효한 USERID와 양수가 아닌 size가 전달되면") {
-                it("400을 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
-                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                    ).andExpect(status().isBadRequest)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-list-failed-invalid-size",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+            describe("GET /api/v1/favorite-places/list") {
+                val targetUri = "/api/v1/favorite-places/list"
+                context("유효한 USERID와 size,sortType,lastId가 전달되면") {
+                    val response = createSliceFavoritePlaceResponse()
+                    val content = response.content[0]
+                    every {
+                        favoritePlaceService.getMyFavoritePlaceList(TEST_USER_ID, TEST_SIZE, TEST_FAVORITE_PLACE_SORT_TYPE, TEST_LAST_ID)
+                    } returns createSliceFavoritePlaceResponse()
+                    it("관심장소 수를 출력한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                                .param(SIZE_PARAM, TEST_SIZE.toString())
+                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
+                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                        ).andExpect(status().isOk)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-list-success",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                    queryParameters(
+                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                    ),
+                                    responseBody(
+                                        "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
+                                        "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
+                                        "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
+                                        "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
+                                        "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
+                                    ),
                                 ),
-                                queryParameters(
-                                    SIZE_PARAM pathDescription "양수가 아닌 츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
-                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                            )
+                    }
+                }
+
+                context("유효한 USERID만 전달되면") {
+                    val response = createSliceFavoritePlaceResponse()
+                    val content = response.content[0]
+                    every {
+                        favoritePlaceService.getMyFavoritePlaceList(TEST_USER_ID, TEST_DEFAULT_SIZE, TEST_FAVORITE_PLACE_SORT_TYPE, null)
+                    } returns createSliceFavoritePlaceResponse()
+                    it("관심장소 수를 출력한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                        ).andExpect(status().isOk)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-list-request-param-null-success",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                    queryParameters(
+                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example "null" isOptional true,
+                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example "null" isOptional true,
+                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example "null" isOptional true,
+                                    ),
+                                    responseBody(
+                                        "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
+                                        "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
+                                        "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
+                                        "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
+                                        "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
+                                    ),
                                 ),
-                            ),
-                        )
+                            )
+                    }
+                }
+
+                context("유효한 USERID와 양수가 아닌 size가 전달되면") {
+                    it("400을 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                                .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
+                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
+                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                        ).andExpect(status().isBadRequest)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-list-failed-invalid-size",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                    queryParameters(
+                                        SIZE_PARAM pathDescription "양수가 아닌 츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
+                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("유효한 USERID와 정의하지 않은 정렬 기준이 전달되면") {
+                    it("400을 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                                .param(SIZE_PARAM, TEST_SIZE.toString())
+                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_INVALID_SORT_TYPE)
+                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                        ).andExpect(status().isBadRequest)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-list-failed-invalid-sort-type",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                    queryParameters(
+                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
+                                        SORT_TYPE_PARAM pathDescription "정의되지 않은 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_INVALID_SORT_TYPE isOptional true,
+                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("유효한 USERID와 양수가 아닌 마지막 ID가 전달되면") {
+                    it("400을 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                                .param(SIZE_PARAM, TEST_SIZE.toString())
+                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
+                                .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
+                        ).andExpect(status().isBadRequest)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-list-failed-invalid-last-id",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                    queryParameters(
+                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                        LAST_ID_PARAM pathDescription "양수가 아닌 마지막 리스트 ID" example TEST_INVALID_LAST_ID isOptional true,
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("유효하지 않은 토큰이 전달되면") {
+                    it("401을 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                                .param(SIZE_PARAM, TEST_SIZE.toString())
+                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
+                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                        ).andExpect(status().isUnauthorized)
+                            .andDo(
+                                createPathDocument(
+                                    "favorite-place-list-failed-invalid-token",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                                    ),
+                                    queryParameters(
+                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                    ),
+                                ),
+                            )
+                    }
                 }
             }
 
-            context("유효한 USERID와 정의하지 않은 정렬 기준이 전달되면") {
-                it("400을 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            .param(SIZE_PARAM, TEST_SIZE.toString())
-                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_INVALID_SORT_TYPE)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                    ).andExpect(status().isBadRequest)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-list-failed-invalid-sort-type",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                ),
-                                queryParameters(
-                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
-                                    SORT_TYPE_PARAM pathDescription "정의되지 않은 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_INVALID_SORT_TYPE isOptional true,
-                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                ),
-                            ),
+            describe("GET /api/v1/favorite-places/list/{userId}") {
+                val targetUri = "/api/v1/favorite-places/list/{userId}"
+                context("유효한 USERID와 size,sortType,lastId가 전달되면") {
+                    val response = createSliceFavoritePlaceResponse()
+                    val content = response.content[0]
+                    every {
+                        favoritePlaceService.getFavoritePlaceList(TEST_USER_ID, TEST_USER_ID, TEST_DEFAULT_SIZE, TEST_FAVORITE_PLACE_SORT_TYPE, TEST_LAST_ID)
+                    } returns createSliceFavoritePlaceResponse()
+                    it("관심장소 리스트를 출력한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri, TEST_USER_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
                         )
+                            .andExpect(status().isOk)
+                            .andDo(
+                                createPathDocument(
+                                    "other-favorite-place-list-success",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                    pathParameters(
+                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                    ),
+                                    queryParameters(
+                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
+                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                    ),
+                                    responseBody(
+                                        "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
+                                        "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
+                                        "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
+                                        "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
+                                        "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("양수가 아닌 USERID가 전달되면") {
+                    it("400을 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri, TEST_INVALID_USER_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                        )
+                            .andExpect(status().isBadRequest)
+                            .andDo(
+                                createPathDocument(
+                                    "other-favorite-place-list-failed-invalid-id",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                    pathParameters(
+                                        "userId" pathDescription "양수가 아닌 USER ID" example TEST_INVALID_USER_ID,
+                                    ),
+                                    queryParameters(
+                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
+                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("양수가 아닌 size가 전달되면") {
+                    it("400을 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri, TEST_USER_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                                .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
+                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                        ).andExpect(status().isBadRequest)
+                            .andDo(
+                                createPathDocument(
+                                    "other-favorite-place-list-failed-invalid-size",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                    pathParameters(
+                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                    ),
+                                    queryParameters(
+                                        SIZE_PARAM pathDescription "양수가 아닌 츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
+                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("유효한 USERID와 정의하지 않은 정렬 기준이 전달되면") {
+                    it("400을 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri, TEST_USER_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_INVALID_SORT_TYPE)
+                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                        ).andExpect(status().isBadRequest)
+                            .andDo(
+                                createPathDocument(
+                                    "other-favorite-place-list-failed-invalid-sort-type",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                    pathParameters(
+                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                    ),
+                                    queryParameters(
+                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
+                                        SORT_TYPE_PARAM pathDescription "정의되지 않은 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_INVALID_SORT_TYPE isOptional true,
+                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("유효한 USERID와 양수가 아닌 마지막 ID가 전달되면") {
+                    it("400을 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri, TEST_USER_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                                .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
+                        ).andExpect(status().isBadRequest)
+                            .andDo(
+                                createPathDocument(
+                                    "other-favorite-place-list-failed-invalid-last-id",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                    ),
+                                    pathParameters(
+                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                    ),
+                                    queryParameters(
+                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                        LAST_ID_PARAM pathDescription "양수가 아닌 마지막 리스트 ID" example TEST_INVALID_LAST_ID isOptional true,
+                                    ),
+                                ),
+                            )
+                    }
+                }
+
+                context("유효하지 않은 토큰이 전달되면") {
+                    it("401을 반환한다.") {
+                        restDocMockMvc.perform(
+                            RestDocumentationRequestBuilders
+                                .get(targetUri, TEST_USER_ID)
+                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                        ).andExpect(status().isUnauthorized)
+                            .andDo(
+                                createPathDocument(
+                                    "other-favorite-place-list-failed-invalid-token",
+                                    requestHeaders(
+                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                                    ),
+                                    pathParameters(
+                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                    ),
+                                    queryParameters(
+                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                    ),
+                                ),
+                            )
+                    }
                 }
             }
 
-            context("유효한 USERID와 양수가 아닌 마지막 ID가 전달되면") {
-                it("400을 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            .param(SIZE_PARAM, TEST_SIZE.toString())
-                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
-                            .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
-                    ).andExpect(status().isBadRequest)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-list-failed-invalid-last-id",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                ),
-                                queryParameters(
-                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                    LAST_ID_PARAM pathDescription "양수가 아닌 마지막 리스트 ID" example TEST_INVALID_LAST_ID isOptional true,
-                                ),
-                            ),
-                        )
-                }
+            afterEach {
+                restDocumentation.afterTest()
             }
-
-            context("유효하지 않은 토큰이 전달되면") {
-                it("401을 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
-                            .param(SIZE_PARAM, TEST_SIZE.toString())
-                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                    ).andExpect(status().isUnauthorized)
-                        .andDo(
-                            createPathDocument(
-                                "favorite-place-list-failed-invalid-token",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                                ),
-                                queryParameters(
-                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                ),
-                            ),
-                        )
-                }
-            }
-        }
-
-        describe("GET /api/v1/favorite-places/list/{userId}") {
-            val targetUri = "/api/v1/favorite-places/list/{userId}"
-            context("유효한 USERID와 size,sortType,lastId가 전달되면") {
-                val response = createSliceFavoritePlaceResponse()
-                val content = response.content[0]
-                every {
-                    favoritePlaceService.getFavoritePlaceList(
-                        TEST_USER_ID,
-                        TEST_USER_ID,
-                        TEST_DEFAULT_SIZE,
-                        TEST_FAVORITE_PLACE_SORT_TYPE,
-                        TEST_LAST_ID,
-                    )
-                } returns createSliceFavoritePlaceResponse()
-                it("관심장소 리스트를 출력한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri, TEST_USER_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                    )
-                        .andExpect(status().isOk)
-                        .andDo(
-                            createPathDocument(
-                                "other-favorite-place-list-success",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                ),
-                                pathParameters(
-                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                ),
-                                queryParameters(
-                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
-                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                ),
-                                responseBody(
-                                    "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
-                                    "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
-                                    "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
-                                    "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
-                                    "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
-                                ),
-                            ),
-                        )
-                }
-            }
-
-            context("양수가 아닌 USERID가 전달되면") {
-                it("400을 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri, TEST_INVALID_USER_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                    )
-                        .andExpect(status().isBadRequest)
-                        .andDo(
-                            createPathDocument(
-                                "other-favorite-place-list-failed-invalid-id",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                ),
-                                pathParameters(
-                                    "userId" pathDescription "양수가 아닌 USER ID" example TEST_INVALID_USER_ID,
-                                ),
-                                queryParameters(
-                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
-                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                ),
-                            ),
-                        )
-                }
-            }
-
-            context("양수가 아닌 size가 전달되면") {
-                it("400을 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri, TEST_USER_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                    ).andExpect(status().isBadRequest)
-                        .andDo(
-                            createPathDocument(
-                                "other-favorite-place-list-failed-invalid-size",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                ),
-                                pathParameters(
-                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                ),
-                                queryParameters(
-                                    SIZE_PARAM pathDescription "양수가 아닌 츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
-                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                ),
-                            ),
-                        )
-                }
-            }
-
-            context("유효한 USERID와 정의하지 않은 정렬 기준이 전달되면") {
-                it("400을 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri, TEST_USER_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_INVALID_SORT_TYPE)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                    ).andExpect(status().isBadRequest)
-                        .andDo(
-                            createPathDocument(
-                                "other-favorite-place-list-failed-invalid-sort-type",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                ),
-                                pathParameters(
-                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                ),
-                                queryParameters(
-                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
-                                    SORT_TYPE_PARAM pathDescription "정의되지 않은 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_INVALID_SORT_TYPE isOptional true,
-                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                ),
-                            ),
-                        )
-                }
-            }
-
-            context("유효한 USERID와 양수가 아닌 마지막 ID가 전달되면") {
-                it("400을 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri, TEST_USER_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
-                    ).andExpect(status().isBadRequest)
-                        .andDo(
-                            createPathDocument(
-                                "other-favorite-place-list-failed-invalid-last-id",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                ),
-                                pathParameters(
-                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                ),
-                                queryParameters(
-                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                    LAST_ID_PARAM pathDescription "양수가 아닌 마지막 리스트 ID" example TEST_INVALID_LAST_ID isOptional true,
-                                ),
-                            ),
-                        )
-                }
-            }
-
-            context("유효하지 않은 토큰이 전달되면") {
-                it("401을 반환한다.") {
-                    restDocMockMvc.perform(
-                        RestDocumentationRequestBuilders
-                            .get(targetUri, TEST_USER_ID)
-                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                    ).andExpect(status().isUnauthorized)
-                        .andDo(
-                            createPathDocument(
-                                "other-favorite-place-list-failed-invalid-token",
-                                requestHeaders(
-                                    HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                                ),
-                                pathParameters(
-                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                ),
-                                queryParameters(
-                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                ),
-                            ),
-                        )
-                }
-            }
-        }
-
-        afterEach {
-            restDocumentation.afterTest()
-        }
-    },
-)
+        },
+    )

--- a/src/test/kotlin/kr/weit/odya/controller/FavoritePlaceControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/FavoritePlaceControllerTest.kt
@@ -26,6 +26,7 @@ import kr.weit.odya.support.TEST_INVALID_LAST_ID
 import kr.weit.odya.support.TEST_INVALID_SIZE
 import kr.weit.odya.support.TEST_INVALID_USER_ID
 import kr.weit.odya.support.TEST_LAST_ID
+import kr.weit.odya.support.TEST_OTHER_USER_ID
 import kr.weit.odya.support.TEST_PLACE_ID
 import kr.weit.odya.support.TEST_SIZE
 import kr.weit.odya.support.TEST_USER_ID
@@ -62,711 +63,797 @@ class FavoritePlaceControllerTest(
     @MockkBean private val favoritePlaceService: FavoritePlaceService,
     private val context: WebApplicationContext,
 ) : DescribeSpec(
-        {
-            val restDocumentation = ManualRestDocumentation()
-            val restDocMockMvc = RestDocsHelper.generateRestDocMockMvc(context, restDocumentation)
+    {
+        val restDocumentation = ManualRestDocumentation()
+        val restDocMockMvc = RestDocsHelper.generateRestDocMockMvc(context, restDocumentation)
 
-            beforeEach {
-                restDocumentation.beforeTest(javaClass, it.name.testName)
+        beforeEach {
+            restDocumentation.beforeTest(javaClass, it.name.testName)
+        }
+
+        describe("POST /api/v1/favorite-places") {
+            val targetUri = "/api/v1/favorite-places"
+            context("유효한 요청 데이터가 전달되면") {
+                val request = createFavoritePlaceRequest()
+                every { favoritePlaceService.createFavoritePlace(TEST_USER_ID, createFavoritePlaceRequest()) } just Runs
+                it("201를 반환한다.") {
+                    restDocMockMvc.post(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        jsonContent(request)
+                    }.andExpect {
+                        status { isCreated() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-create-success",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            requestBody(
+                                "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
+                            ),
+                        )
+                    }
+                }
             }
 
-            describe("POST /api/v1/favorite-places") {
-                val targetUri = "/api/v1/favorite-places"
-                context("유효한 요청 데이터가 전달되면") {
-                    val request = createFavoritePlaceRequest()
-                    every { favoritePlaceService.createFavoritePlace(TEST_USER_ID, createFavoritePlaceRequest()) } just Runs
-                    it("201를 반환한다.") {
-                        restDocMockMvc.post(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            jsonContent(request)
-                        }.andExpect {
-                            status { isCreated() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-create-success",
+            context("유효한 토큰이면서 장소 ID가 빈 문자열이면") {
+                val request = createFavoritePlaceRequest().copy(placeId = " ")
+                it("400를 반환한다.") {
+                    restDocMockMvc.post(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        jsonContent(request)
+                    }.andExpect {
+                        status { isBadRequest() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-create-failed-empty-place-id",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            requestBody(
+                                "placeId" type JsonFieldType.STRING description "공백인 장소 ID" example """ """,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("가입되어 있지 않은 USERID이 주어지는 경우") {
+                val request = createFavoritePlaceRequest()
+                it("401를 반환한다.") {
+                    restDocMockMvc.post(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN)
+                        jsonContent(request)
+                    }.andExpect {
+                        status { isUnauthorized() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-create-failed-not-exist-user-id",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            requestBody(
+                                "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효한 토큰이지만, 이미 관심 장소인 경우") {
+                val request = createFavoritePlaceRequest()
+                every {
+                    favoritePlaceService.createFavoritePlace(TEST_USER_ID, createFavoritePlaceRequest())
+                } throws ExistResourceException(EXIST_FAVORITE_PLACE_ERROR_MESSAGE)
+                it("409를 반환한다.") {
+                    restDocMockMvc.post(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        jsonContent(request)
+                    }.andExpect {
+                        status { isConflict() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-create-failed-already-exist-favorite-place",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            requestBody(
+                                "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효하지 않은 토큰이 전달되면") {
+                val request = createFavoritePlaceRequest()
+                it("401를 반환한다.") {
+                    restDocMockMvc.post(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                        jsonContent(request)
+                    }.andExpect {
+                        status { isUnauthorized() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-create-failed-invalid-token",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                            ),
+                            requestBody(
+                                "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+
+        describe("DELETE /api/v1/favorite-places/{id}") {
+            val targetUri = "/api/v1/favorite-places/{id}"
+            context("유효한 요청 데이터가 전달되면") {
+                every { favoritePlaceService.deleteFavoritePlace(TEST_USER_ID, TEST_FAVORITE_PLACE_ID) } just Runs
+                it("204를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .delete(targetUri, TEST_FAVORITE_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    ).andExpect(status().isNoContent)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-delete-success",
+                                pathParameters(
+                                    "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
+                                ),
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                                requestBody(
-                                    "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
-                                ),
-                            )
-                        }
-                    }
+                            ),
+                        )
                 }
+            }
 
-                context("유효한 토큰이면서 장소 ID가 빈 문자열이면") {
-                    val request = createFavoritePlaceRequest().copy(placeId = " ")
-                    it("400를 반환한다.") {
-                        restDocMockMvc.post(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            jsonContent(request)
-                        }.andExpect {
-                            status { isBadRequest() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-create-failed-empty-place-id",
+            context("양수가 아닌 관심 장소 ID인 경우") {
+                it("400를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .delete(targetUri, TEST_INVALID_FAVORITE_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-delete-failed-invalid-favorite-place-id",
+                                pathParameters(
+                                    "id" pathDescription "양수가 아닌 관심 장소 ID" example TEST_INVALID_FAVORITE_PLACE_ID,
+                                ),
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                                requestBody(
-                                    "placeId" type JsonFieldType.STRING description "공백인 장소 ID" example """ """,
-                                ),
-                            )
-                        }
-                    }
+                            ),
+                        )
                 }
+            }
 
-                context("가입되어 있지 않은 USERID이 주어지는 경우") {
-                    val request = createFavoritePlaceRequest()
-                    it("401를 반환한다.") {
-                        restDocMockMvc.post(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN)
-                            jsonContent(request)
-                        }.andExpect {
-                            status { isUnauthorized() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-create-failed-not-exist-user-id",
+            context("가입되어 있지 않은 USERID이 주어지는 경우") {
+                it("401를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .delete(targetUri, TEST_FAVORITE_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN),
+                    ).andExpect(status().isUnauthorized)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-delete-failed-not-exist-user-id",
+                                pathParameters(
+                                    "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
+                                ),
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                                requestBody(
-                                    "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
-                                ),
-                            )
-                        }
-                    }
+                            ),
+                        )
                 }
+            }
 
-                context("유효한 토큰이지만, 이미 관심 장소인 경우") {
-                    val request = createFavoritePlaceRequest()
-                    every {
-                        favoritePlaceService.createFavoritePlace(TEST_USER_ID, createFavoritePlaceRequest())
-                    } throws ExistResourceException(EXIST_FAVORITE_PLACE_ERROR_MESSAGE)
-                    it("409를 반환한다.") {
-                        restDocMockMvc.post(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            jsonContent(request)
-                        }.andExpect {
-                            status { isConflict() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-create-failed-already-exist-favorite-place",
+            context("유효한 토큰이지만, 관심 장소가 아닌 경우") {
+                every {
+                    favoritePlaceService.deleteFavoritePlace(TEST_USER_ID, TEST_EXIST_FAVORITE_PLACE_ID)
+                } throws NoSuchElementException(NOT_FOUND_FAVORITE_PLACE_ERROR_MESSAGE)
+                it("404를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .delete(targetUri, TEST_EXIST_FAVORITE_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    ).andExpect(status().isNotFound)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-delete-failed-not-exist-favorite-place-id",
+                                pathParameters(
+                                    "id" pathDescription "존재하지 않는 관심 장소 ID" example TEST_EXIST_FAVORITE_PLACE_ID,
+                                ),
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                                requestBody(
-                                    "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
-                                ),
-                            )
-                        }
-                    }
+                            ),
+                        )
                 }
+            }
 
-                context("유효하지 않은 토큰이 전달되면") {
-                    val request = createFavoritePlaceRequest()
-                    it("401를 반환한다.") {
-                        restDocMockMvc.post(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
-                            jsonContent(request)
-                        }.andExpect {
-                            status { isUnauthorized() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-create-failed-invalid-token",
+            context("유효하지 않은 토큰이 전달되면") {
+                it("401를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .delete(targetUri, TEST_FAVORITE_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
+                    ).andExpect(status().isUnauthorized)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-delete-failed-invalid-token",
+                                pathParameters(
+                                    "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
+                                ),
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
                                 ),
-                                requestBody(
-                                    "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
-                                ),
-                            )
-                        }
-                    }
+                            ),
+                        )
                 }
             }
+        }
 
-            describe("DELETE /api/v1/favorite-places/{id}") {
-                val targetUri = "/api/v1/favorite-places/{id}"
-                context("유효한 요청 데이터가 전달되면") {
-                    every { favoritePlaceService.deleteFavoritePlace(TEST_USER_ID, TEST_FAVORITE_PLACE_ID) } just Runs
-                    it("204를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .delete(targetUri, TEST_FAVORITE_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                        ).andExpect(status().isNoContent)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-delete-success",
-                                    pathParameters(
-                                        "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
+        describe("GET /api/v1/favorite-places/{placeId}") {
+            val targetUri = "/api/v1/favorite-places/{placeId}"
+            context("유효한 요청 데이터가 전달되면") {
+                every { favoritePlaceService.getFavoritePlace(TEST_USER_ID, TEST_PLACE_ID) } returns true
+                it("200를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    ).andExpect(status().isOk)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-check-success",
+                                pathParameters(
+                                    "placeId" pathDescription "장소 ID" example TEST_PLACE_ID,
                                 ),
-                            )
-                    }
-                }
-
-                context("양수가 아닌 관심 장소 ID인 경우") {
-                    it("400를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .delete(targetUri, TEST_INVALID_FAVORITE_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-delete-failed-invalid-favorite-place-id",
-                                    pathParameters(
-                                        "id" pathDescription "양수가 아닌 관심 장소 ID" example TEST_INVALID_FAVORITE_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("가입되어 있지 않은 USERID이 주어지는 경우") {
-                    it("401를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .delete(targetUri, TEST_FAVORITE_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN),
-                        ).andExpect(status().isUnauthorized)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-delete-failed-not-exist-user-id",
-                                    pathParameters(
-                                        "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 토큰이지만, 관심 장소가 아닌 경우") {
-                    every {
-                        favoritePlaceService.deleteFavoritePlace(TEST_USER_ID, TEST_EXIST_FAVORITE_PLACE_ID)
-                    } throws NoSuchElementException(NOT_FOUND_FAVORITE_PLACE_ERROR_MESSAGE)
-                    it("404를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .delete(targetUri, TEST_EXIST_FAVORITE_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                        ).andExpect(status().isNotFound)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-delete-failed-not-exist-favorite-place-id",
-                                    pathParameters(
-                                        "id" pathDescription "존재하지 않는 관심 장소 ID" example TEST_EXIST_FAVORITE_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효하지 않은 토큰이 전달되면") {
-                    it("401를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .delete(targetUri, TEST_FAVORITE_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
-                        ).andExpect(status().isUnauthorized)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-delete-failed-invalid-token",
-                                    pathParameters(
-                                        "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-            }
-
-            describe("GET /api/v1/favorite-places/{placeId}") {
-                val targetUri = "/api/v1/favorite-places/{placeId}"
-                context("유효한 요청 데이터가 전달되면") {
-                    every { favoritePlaceService.getFavoritePlace(TEST_USER_ID, TEST_PLACE_ID) } returns true
-                    it("200를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                        ).andExpect(status().isOk)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-check-success",
-                                    pathParameters(
-                                        "placeId" pathDescription "장소 ID" example TEST_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("placeId가 공백인 경우") {
-                    it("400를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, " ")
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-check-failed-empty-place-id",
-                                    pathParameters(
-                                        "placeId" pathDescription "공백인 장소 ID" example " ",
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효하지 않은 토큰 전달되면") {
-                    it("401를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
-                        ).andExpect(status().isUnauthorized)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-check-failed-invalid-token",
-                                    pathParameters(
-                                        "placeId" pathDescription "장소 ID" example TEST_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-            }
-
-            describe("GET /api/v1/favorite-places/counts") {
-                val targetUri = "/api/v1/favorite-places/counts"
-                context("유효한 USERID가 전달되면") {
-                    every { favoritePlaceService.getFavoritePlaceCount(TEST_USER_ID) } returns TEST_FAVORITE_PLACE_COUNT
-                    it("관심장소 수를 출력한다.") {
-                        restDocMockMvc.get(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                        }.andExpect {
-                            status { isOk() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-count-success",
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                            )
-                        }
-                    }
+                            ),
+                        )
                 }
+            }
 
-                context("유효하지않은 토큰이 전달되면") {
-                    it("401을 출력한다.") {
-                        restDocMockMvc.get(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
-                        }.andExpect {
-                            status { isUnauthorized() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-count-failed-invalid-token",
+            context("placeId가 공백인 경우") {
+                it("400를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, " ")
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-check-failed-empty-place-id",
+                                pathParameters(
+                                    "placeId" pathDescription "공백인 장소 ID" example " ",
+                                ),
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효하지 않은 토큰 전달되면") {
+                it("401를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
+                    ).andExpect(status().isUnauthorized)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-check-failed-invalid-token",
+                                pathParameters(
+                                    "placeId" pathDescription "장소 ID" example TEST_PLACE_ID,
+                                ),
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
                                 ),
-                            )
-                        }
-                    }
-                }
-            }
-
-            describe("GET /api/v1/favorite-places/list") {
-                val targetUri = "/api/v1/favorite-places/list"
-                context("유효한 USERID와 size,sortType,lastId가 전달되면") {
-                    val response = createSliceFavoritePlaceResponse()
-                    val content = response.content[0]
-                    every {
-                        favoritePlaceService.getMyFavoritePlaceList(TEST_USER_ID, TEST_SIZE, TEST_FAVORITE_PLACE_SORT_TYPE, TEST_LAST_ID)
-                    } returns createSliceFavoritePlaceResponse()
-                    it("관심장소 수를 출력한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(SIZE_PARAM, TEST_SIZE.toString())
-                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isOk)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-list-success",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                    responseBody(
-                                        "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
-                                        "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
-                                        "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
-                                        "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
-                                        "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 USERID만 전달되면") {
-                    val response = createSliceFavoritePlaceResponse()
-                    val content = response.content[0]
-                    every {
-                        favoritePlaceService.getMyFavoritePlaceList(TEST_USER_ID, TEST_DEFAULT_SIZE, TEST_FAVORITE_PLACE_SORT_TYPE, null)
-                    } returns createSliceFavoritePlaceResponse()
-                    it("관심장소 수를 출력한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                        ).andExpect(status().isOk)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-list-request-param-null-success",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example "null" isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example "null" isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example "null" isOptional true,
-                                    ),
-                                    responseBody(
-                                        "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
-                                        "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
-                                        "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
-                                        "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
-                                        "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 USERID와 양수가 아닌 size가 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
-                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-list-failed-invalid-size",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "양수가 아닌 츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 USERID와 정의하지 않은 정렬 기준이 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(SIZE_PARAM, TEST_SIZE.toString())
-                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_INVALID_SORT_TYPE)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-list-failed-invalid-sort-type",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "정의되지 않은 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_INVALID_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 USERID와 양수가 아닌 마지막 ID가 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(SIZE_PARAM, TEST_SIZE.toString())
-                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
-                                .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-list-failed-invalid-last-id",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "양수가 아닌 마지막 리스트 ID" example TEST_INVALID_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효하지 않은 토큰이 전달되면") {
-                    it("401을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
-                                .param(SIZE_PARAM, TEST_SIZE.toString())
-                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isUnauthorized)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-list-failed-invalid-token",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-            }
-
-            describe("GET /api/v1/favorite-places/list/{userId}") {
-                val targetUri = "/api/v1/favorite-places/list/{userId}"
-                context("유효한 USERID와 size,sortType,lastId가 전달되면") {
-                    val response = createSliceFavoritePlaceResponse()
-                    val content = response.content[0]
-                    every {
-                        favoritePlaceService.getFavoritePlaceList(TEST_USER_ID, TEST_USER_ID, TEST_DEFAULT_SIZE, TEST_FAVORITE_PLACE_SORT_TYPE, TEST_LAST_ID)
-                    } returns createSliceFavoritePlaceResponse()
-                    it("관심장소 리스트를 출력한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_USER_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                            ),
                         )
-                            .andExpect(status().isOk)
-                            .andDo(
-                                createPathDocument(
-                                    "other-favorite-place-list-success",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    pathParameters(
-                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                    responseBody(
-                                        "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
-                                        "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
-                                        "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
-                                        "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
-                                        "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
-                                    ),
-                                ),
-                            )
-                    }
                 }
+            }
+        }
 
-                context("양수가 아닌 USERID가 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_INVALID_USER_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+        describe("GET /api/v1/favorite-places/counts") {
+            val targetUri = "/api/v1/favorite-places/counts"
+            context("유효한 USERID가 전달되면") {
+                every { favoritePlaceService.getFavoritePlaceCount(TEST_USER_ID) } returns TEST_FAVORITE_PLACE_COUNT
+                it("관심장소 수를 출력한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                    }.andExpect {
+                        status {  isOk() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-count-success",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
                         )
-                            .andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "other-favorite-place-list-failed-invalid-id",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    pathParameters(
-                                        "userId" pathDescription "양수가 아닌 USER ID" example TEST_INVALID_USER_ID,
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("양수가 아닌 size가 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_USER_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "other-favorite-place-list-failed-invalid-size",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    pathParameters(
-                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "양수가 아닌 츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 USERID와 정의하지 않은 정렬 기준이 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_USER_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_INVALID_SORT_TYPE)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "other-favorite-place-list-failed-invalid-sort-type",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    pathParameters(
-                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "정의되지 않은 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_INVALID_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 USERID와 양수가 아닌 마지막 ID가 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_USER_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "other-favorite-place-list-failed-invalid-last-id",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    pathParameters(
-                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "양수가 아닌 마지막 리스트 ID" example TEST_INVALID_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효하지 않은 토큰이 전달되면") {
-                    it("401을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_USER_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isUnauthorized)
-                            .andDo(
-                                createPathDocument(
-                                    "other-favorite-place-list-failed-invalid-token",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                                    ),
-                                    pathParameters(
-                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
                     }
                 }
             }
 
-            afterEach {
-                restDocumentation.afterTest()
+            context("유효하지않은 토큰이 전달되면") {
+                it("401을 출력한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                    }.andExpect {
+                        status { isUnauthorized() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-count-failed-invalid-token",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                            ),
+                        )
+                    }
+                }
             }
-        },
-    )
+        }
+
+        describe("GET /api/v1/favorite-places/counts/{userId}") {
+            val targetUri = "/api/v1/favorite-places/counts/{userId}"
+            context("유효한 USERID가 전달되면") {
+                every { favoritePlaceService.getFavoritePlaceCount(TEST_OTHER_USER_ID) } returns TEST_FAVORITE_PLACE_COUNT
+                it("관심장소 수를 출력한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_OTHER_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    )
+                        .andExpect(status().isOk)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-count-success",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "조회할 USER ID" example TEST_OTHER_USER_ID,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("양수가 아닌 USERID가 전달되면") {
+                it("400을 출력한다") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_INVALID_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    )
+                        .andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-count-failed-invalid-favorite-place-id",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "양수가 아닌 USER ID" example TEST_INVALID_USER_ID,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효하지않은 토큰이 전달되면") {
+                it("401을 출력한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_OTHER_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
+                    )
+                        .andExpect(status().isUnauthorized())
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-count-failed-invalid-token",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "조회할 USER ID" example TEST_OTHER_USER_ID,
+                                ),
+                            ),
+                        )
+                }
+            }
+        }
+
+        describe("GET /api/v1/favorite-places/list") {
+            val targetUri = "/api/v1/favorite-places/list"
+            context("유효한 USERID와 size,sortType,lastId가 전달되면") {
+                val response = createSliceFavoritePlaceResponse()
+                val content = response.content[0]
+                every {
+                    favoritePlaceService.getMyFavoritePlaceList(
+                        TEST_USER_ID,
+                        TEST_SIZE,
+                        TEST_FAVORITE_PLACE_SORT_TYPE,
+                        TEST_LAST_ID,
+                    )
+                } returns createSliceFavoritePlaceResponse()
+                it("관심장소 수를 출력한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(SIZE_PARAM, TEST_SIZE.toString())
+                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isOk)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-list-success",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                                responseBody(
+                                    "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
+                                    "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
+                                    "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
+                                    "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
+                                    "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효한 USERID만 전달되면") {
+                val response = createSliceFavoritePlaceResponse()
+                val content = response.content[0]
+                every {
+                    favoritePlaceService.getMyFavoritePlaceList(
+                        TEST_USER_ID,
+                        TEST_DEFAULT_SIZE,
+                        TEST_FAVORITE_PLACE_SORT_TYPE,
+                        null,
+                    )
+                } returns createSliceFavoritePlaceResponse()
+                it("관심장소 수를 출력한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    ).andExpect(status().isOk)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-list-request-param-null-success",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example "null" isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example "null" isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example "null" isOptional true,
+                                ),
+                                responseBody(
+                                    "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
+                                    "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
+                                    "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
+                                    "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
+                                    "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효한 USERID와 양수가 아닌 size가 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
+                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-list-failed-invalid-size",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "양수가 아닌 츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효한 USERID와 정의하지 않은 정렬 기준이 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(SIZE_PARAM, TEST_SIZE.toString())
+                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_INVALID_SORT_TYPE)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-list-failed-invalid-sort-type",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "정의되지 않은 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_INVALID_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효한 USERID와 양수가 아닌 마지막 ID가 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(SIZE_PARAM, TEST_SIZE.toString())
+                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
+                            .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-list-failed-invalid-last-id",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "양수가 아닌 마지막 리스트 ID" example TEST_INVALID_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효하지 않은 토큰이 전달되면") {
+                it("401을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                            .param(SIZE_PARAM, TEST_SIZE.toString())
+                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isUnauthorized)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-list-failed-invalid-token",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+        }
+
+        describe("GET /api/v1/favorite-places/list/{userId}") {
+            val targetUri = "/api/v1/favorite-places/list/{userId}"
+            context("유효한 USERID와 size,sortType,lastId가 전달되면") {
+                val response = createSliceFavoritePlaceResponse()
+                val content = response.content[0]
+                every {
+                    favoritePlaceService.getFavoritePlaceList(
+                        TEST_USER_ID,
+                        TEST_USER_ID,
+                        TEST_DEFAULT_SIZE,
+                        TEST_FAVORITE_PLACE_SORT_TYPE,
+                        TEST_LAST_ID,
+                    )
+                } returns createSliceFavoritePlaceResponse()
+                it("관심장소 리스트를 출력한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    )
+                        .andExpect(status().isOk)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-list-success",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                                responseBody(
+                                    "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
+                                    "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
+                                    "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
+                                    "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
+                                    "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("양수가 아닌 USERID가 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_INVALID_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    )
+                        .andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-list-failed-invalid-id",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "양수가 아닌 USER ID" example TEST_INVALID_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("양수가 아닌 size가 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-list-failed-invalid-size",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "양수가 아닌 츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효한 USERID와 정의하지 않은 정렬 기준이 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_INVALID_SORT_TYPE)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-list-failed-invalid-sort-type",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "정의되지 않은 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_INVALID_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효한 USERID와 양수가 아닌 마지막 ID가 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-list-failed-invalid-last-id",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "양수가 아닌 마지막 리스트 ID" example TEST_INVALID_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효하지 않은 토큰이 전달되면") {
+                it("401을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isUnauthorized)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-list-failed-invalid-token",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+        }
+
+        afterEach {
+            restDocumentation.afterTest()
+        }
+    },
+)


### PR DESCRIPTION
### 개요
- 타인의 관심 장소 수를 조회할 수 있어야한다.

### 변경사항
- 타인의 관심 장소 수 조회 API 추가

### 관련 지라 및 위키 링크
- [ODYA-248](https://weit.atlassian.net/browse/ODYA-248)

### 리뷰어에게 하고 싶은 말
- 지혜님이 제보해주셔서 처리했습니다 👍 

