### PR TITLE
ODYA-255 타인의 팔로잉 팔로워 검색 API

### DIFF
--- a/src/docs/asciidoc/follow.adoc
+++ b/src/docs/asciidoc/follow.adoc
@@ -164,19 +164,19 @@ operation::follow-controller-test/search-other-followings-fail-invalid-user-id[s
 
 === *9-3 실패 - 닉네임이 공백인 경우*
 
-operation::follow-controller-test/search-followings-fail-nickname-null[snippets='http-request,request-headers,query-parameters,http-response']
+operation::follow-controller-test/search-other-followings-fail-nickname-blank[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
 === *9-4 실패 - 유효하지 않은 마지막 id*
 
-operation::follow-controller-test/search-followings-fail-invalid-last-id[snippets='http-request,request-headers,query-parameters,http-response']
+operation::follow-controller-test/search-other-followings-fail-invalid-last-id[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
 === *9-5 실패 - 유효하지 않은 사이즈*
 
-operation::follow-controller-test/search-followings-fail-invalid-size[snippets='http-request,request-headers,query-parameters,http-response']
+operation::follow-controller-test/search-other-followings-fail-invalid-size[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
 === *9-6 실패 - 유효하지 않은 토큰*
 
-operation::follow-controller-test/search-followings-fail-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']
+operation::follow-controller-test/search-other-followings-fail-invalid-token[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
 [[타인의-팔로워-검색-API]]
 == *10. 타인의 팔로워 검색 API*
@@ -191,19 +191,19 @@ operation::follow-controller-test/search-other-followers-fail-invalid-user-id[sn
 
 === *10-3 실패 - 닉네임이 공백인 경우*
 
-operation::follow-controller-test/search-followers-fail-nickname-null[snippets='http-request,request-headers,query-parameters,http-response']
+operation::follow-controller-test/search-other-followers-fail-nickname-blank[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
 === *10-4 실패 - 유효하지 않은 마지막 id*
 
-operation::follow-controller-test/search-followers-fail-invalid-last-id[snippets='http-request,request-headers,query-parameters,http-response']
+operation::follow-controller-test/search-other-followers-fail-invalid-last-id[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
 === *10-5 실패 - 유효하지 않은 사이즈*
 
-operation::follow-controller-test/search-followers-fail-invalid-size[snippets='http-request,request-headers,query-parameters,http-response']
+operation::follow-controller-test/search-other-followers-fail-invalid-size[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
 === *10-6 실패 - 유효하지 않은 토큰*
 
-operation::follow-controller-test/search-followers-fail-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']
+operation::follow-controller-test/search-other-followers-fail-invalid-token[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
 
 
 [[알수도-있는-유저-검색-API]]

--- a/src/docs/asciidoc/follow.adoc
+++ b/src/docs/asciidoc/follow.adoc
@@ -151,45 +151,100 @@ operation::follow-controller-test/search-followers-fail-invalid-size[snippets='h
 
 operation::follow-controller-test/search-followers-fail-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']
 
-[[알수도-있는-유저-검색-API]]
-== *9. 알수도 있는 유저 검색 API*
+[[타인의-팔로잉-검색-API]]
+== *9. 타인의 팔로잉 검색 API*
 
 === *9-1 성공*
 
+operation::follow-controller-test/search-other-followings-success[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
+
+=== *9-2 실패 - 검색할 유저 ID가 음수인 경우*
+
+operation::follow-controller-test/search-other-followings-fail-invalid-user-id[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
+
+=== *9-3 실패 - 닉네임이 공백인 경우*
+
+operation::follow-controller-test/search-followings-fail-nickname-null[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *9-4 실패 - 유효하지 않은 마지막 id*
+
+operation::follow-controller-test/search-followings-fail-invalid-last-id[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *9-5 실패 - 유효하지 않은 사이즈*
+
+operation::follow-controller-test/search-followings-fail-invalid-size[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *9-6 실패 - 유효하지 않은 토큰*
+
+operation::follow-controller-test/search-followings-fail-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']
+
+[[타인의-팔로워-검색-API]]
+== *10. 타인의 팔로워 검색 API*
+
+=== *10-1 성공*
+
+operation::follow-controller-test/search-other-followers-success[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
+
+=== *10-2 실패 - 검색할 유저 ID가 음수인 경우*
+
+operation::follow-controller-test/search-other-followers-fail-invalid-user-id[snippets='http-request,request-headers,path-parameters,query-parameters,http-response']
+
+=== *10-3 실패 - 닉네임이 공백인 경우*
+
+operation::follow-controller-test/search-followers-fail-nickname-null[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *10-4 실패 - 유효하지 않은 마지막 id*
+
+operation::follow-controller-test/search-followers-fail-invalid-last-id[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *10-5 실패 - 유효하지 않은 사이즈*
+
+operation::follow-controller-test/search-followers-fail-invalid-size[snippets='http-request,request-headers,query-parameters,http-response']
+
+=== *10-6 실패 - 유효하지 않은 토큰*
+
+operation::follow-controller-test/search-followers-fail-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']
+
+
+[[알수도-있는-유저-검색-API]]
+== *11. 알수도 있는 유저 검색 API*
+
+=== *11-1 성공*
+
 operation::follow-controller-test/get-may-know-success[snippets='http-request,request-headers,query-parameters,http-response']
 
-=== *9-2 실패 - 유효하지 않은 마지막 id*
+=== *11-2 실패 - 유효하지 않은 마지막 id*
 
 operation::follow-controller-test/get-may-know-fail-invalid-last-id[snippets='http-request,request-headers,query-parameters,http-response']
 
-=== *9-3 실패 - 유효하지 않은 사이즈*
+=== *11-3 실패 - 유효하지 않은 사이즈*
 
 operation::follow-controller-test/get-may-know-fail-invalid-size[snippets='http-request,request-headers,query-parameters,http-response']
 
-=== *9-4 실패 - 가입하지 않은 유저*
+=== *11-4 실패 - 가입하지 않은 유저*
 
 operation::follow-controller-test/get-may-know-fail-not-registered-user[snippets='http-request,request-headers,query-parameters,http-response']
 
-=== *9-5 실패 - 유효하지 않은 토큰*
+=== *11-5 실패 - 유효하지 않은 토큰*
 
 operation::follow-controller-test/get-may-know-fail-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']
 
 [[방문한-친구수-조회-API]]
 
-== *10. 방문한 친구수 조회 API*
+== *12. 방문한 친구수 조회 API*
 
-=== *10-1 성공*
+=== *12-1 성공*
 
 operation::follow-controller-test/get-visited-followings-success[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *10-2 실패 - 잘못된 장소 Id*
+=== *12-2 실패 - 잘못된 장소 Id*
 
 operation::follow-controller-test/get-visited-followings-fail-invalid-placeId[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *10-3 실패 - 가입되어 있지 않은 USER*
+=== *12-3 실패 - 가입되어 있지 않은 USER*
 
 operation::follow-controller-test/get-visited-followings-fail-not-registered-user[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *10-4 실패 - 유효하지 않은 토큰*
+=== *12-4 실패 - 유효하지 않은 토큰*
 
 operation::follow-controller-test/get-visited-followings-fail-invalid-token[snippets='http-request,request-headers,path-parameters,http-response']

--- a/src/main/kotlin/kr/weit/odya/controller/FollowController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/FollowController.kt
@@ -109,7 +109,7 @@ class FollowController(
         @RequestParam(name = "lastId", required = false)
         lastId: Long?,
     ): ResponseEntity<SliceResponse<FollowUserResponse>> {
-        return ResponseEntity.ok(followService.searchByFollowingNickname(userId, nickname, size, lastId))
+        return ResponseEntity.ok(followService.searchByFollowingNickname(userId, userId, nickname, size, lastId))
     }
 
     @GetMapping("/followers/search")
@@ -125,7 +125,45 @@ class FollowController(
         @RequestParam(name = "lastId", required = false)
         lastId: Long?,
     ): ResponseEntity<SliceResponse<FollowUserResponse>> {
-        return ResponseEntity.ok(followService.searchByFollowerNickname(userId, nickname, size, lastId))
+        return ResponseEntity.ok(followService.searchByFollowerNickname(userId, userId, nickname, size, lastId))
+    }
+
+    @GetMapping("/{userId}/followings/search")
+    fun otherFollowingNicknameSearch(
+        @LoginUserId loginUserId: Long,
+        @Positive(message = "USER ID는 양수여야 합니다.")
+        @PathVariable("userId")
+        userId: Long,
+        @NotBlank(message = "검색할 닉네임은 필수입니다.")
+        @RequestParam("nickname")
+        nickname: String,
+        @Positive(message = "사이즈는 양수여야 합니다.")
+        @RequestParam(name = "size", required = false, defaultValue = "10")
+        size: Int,
+        @Positive(message = "마지막 Id는 양수여야 합니다.")
+        @RequestParam(name = "lastId", required = false)
+        lastId: Long?,
+    ): ResponseEntity<SliceResponse<FollowUserResponse>> {
+        return ResponseEntity.ok(followService.searchByFollowingNickname(loginUserId, userId, nickname, size, lastId))
+    }
+
+    @GetMapping("/{userId}/followers/search")
+    fun otherFollowerNickNameSearch(
+        @LoginUserId loginUserId: Long,
+        @Positive(message = "USER ID는 양수여야 합니다.")
+        @PathVariable("userId")
+        userId: Long,
+        @NotBlank(message = "검색할 닉네임은 필수입니다.")
+        @RequestParam("nickname")
+        nickname: String,
+        @Positive(message = "사이즈는 양수여야 합니다.")
+        @RequestParam(name = "size", required = false, defaultValue = "10")
+        size: Int,
+        @Positive(message = "마지막 Id는 양수여야 합니다.")
+        @RequestParam(name = "lastId", required = false)
+        lastId: Long?,
+    ): ResponseEntity<SliceResponse<FollowUserResponse>> {
+        return ResponseEntity.ok(followService.searchByFollowerNickname(loginUserId, userId, nickname, size, lastId))
     }
 
     @GetMapping("/may-know") // 페이스 북에서는 알수도 있는 친구를 you may know라고 표현하길래 따라해봤습니다

--- a/src/main/kotlin/kr/weit/odya/service/FollowService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/FollowService.kt
@@ -116,23 +116,8 @@ class FollowService(
     }
 
     @Transactional(readOnly = true)
-    fun searchByFollowingNickname(userId: Long, nickname: String, size: Int, lastId: Long?): SliceResponse<FollowUserResponse> {
-        val usersDocuments = usersDocumentRepository.getByNickname(nickname)
-        val userIds = usersDocuments.map { it.id }
-
-        val followings =
-            followRepository.getByFollowerIdAndFollowingIdIn(userId, userIds, size + 1, lastId).map {
-                FollowUserResponse(
-                    it.following,
-                    fileService.getPreAuthenticatedObjectUrl(it.following.profile.profileName),
-                    true,
-                )
-            }
-        return SliceResponse(size, followings)
-    }
-
-    @Transactional(readOnly = true)
-    fun searchByFollowerNickname(
+    fun searchByFollowingNickname(
+        loginUserId: Long,
         userId: Long,
         nickname: String,
         size: Int,
@@ -140,14 +125,38 @@ class FollowService(
     ): SliceResponse<FollowUserResponse> {
         val usersDocuments = usersDocumentRepository.getByNickname(nickname)
         val userIds = usersDocuments.map { it.id }
-        val followingIds = followRepository.getFollowingIds(userId)
-        val followers = followRepository.getByFollowingIdAndFollowerIdIn(userId, userIds, size + 1, lastId).map {
-            FollowUserResponse(
-                it.follower,
-                fileService.getPreAuthenticatedObjectUrl(it.follower.profile.profileName),
-                it.follower.id in followingIds,
-            )
-        }
+        val followingIds = followRepository.getFollowingIds(loginUserId)
+
+        val followings =
+            followRepository.getByFollowerIdAndFollowingIdIn(userId, userIds, size + 1, lastId).map {
+                FollowUserResponse(
+                    it.following,
+                    fileService.getPreAuthenticatedObjectUrl(it.following.profile.profileName),
+                    it.following.id in followingIds,
+                )
+            }
+        return SliceResponse(size, followings)
+    }
+
+    @Transactional(readOnly = true)
+    fun searchByFollowerNickname(
+        loginUserId: Long,
+        userId: Long,
+        nickname: String,
+        size: Int,
+        lastId: Long?,
+    ): SliceResponse<FollowUserResponse> {
+        val usersDocuments = usersDocumentRepository.getByNickname(nickname)
+        val userIds = usersDocuments.map { it.id }
+        val followingIds = followRepository.getFollowingIds(loginUserId)
+        val followers =
+            followRepository.getByFollowingIdAndFollowerIdIn(userId, userIds, size + 1, lastId).map {
+                FollowUserResponse(
+                    it.follower,
+                    fileService.getPreAuthenticatedObjectUrl(it.follower.profile.profileName),
+                    it.follower.id in followingIds,
+                )
+            }
         return SliceResponse(size, followers)
     }
 

--- a/src/main/kotlin/kr/weit/odya/service/FollowService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/FollowService.kt
@@ -84,7 +84,7 @@ class FollowService(
                 FollowUserResponse(
                     it.following,
                     fileService.getPreAuthenticatedObjectUrl(it.following.profile.profileName),
-                    it.follower.id in followingIds,
+                    it.following.id in followingIds,
                 )
             }
         return SliceResponse(pageable, followingList)

--- a/src/test/kotlin/kr/weit/odya/service/FollowServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/FollowServiceTest.kt
@@ -224,8 +224,9 @@ class FollowServiceTest : DescribeSpec(
                     )
                 } returns listOf(createFollow(following = user))
                 every { fileService.getPreAuthenticatedObjectUrl(TEST_DEFAULT_PROFILE_PNG) } returns TEST_PROFILE_URL
+                every { followRepository.findFollowingIdsByFollowerId(TEST_OTHER_USER_ID) } returns listOf(TEST_ANOTHER_USER_ID)
                 it("유저를 조회 한다") {
-                    shouldNotThrowAny { followService.searchByFollowingNickname(TEST_USER_ID, TEST_NICKNAME, 10, null) }
+                    shouldNotThrowAny { followService.searchByFollowingNickname(TEST_OTHER_USER_ID, TEST_USER_ID, TEST_NICKNAME, 10, null) }
                 }
             }
         }
@@ -236,9 +237,17 @@ class FollowServiceTest : DescribeSpec(
                 every { usersDocumentRepository.getByNickname(TEST_NICKNAME) } returns listOf(createUsersDocument(user))
                 every { followRepository.getByFollowingIdAndFollowerIdIn(any(), any(), any(), any()) } returns listOf(createFollow(following = user))
                 every { fileService.getPreAuthenticatedObjectUrl(TEST_DEFAULT_PROFILE_PNG) } returns TEST_PROFILE_URL
-                every { followRepository.findFollowingIdsByFollowerId(TEST_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
+                every { followRepository.findFollowingIdsByFollowerId(TEST_OTHER_USER_ID) } returns listOf(TEST_ANOTHER_USER_ID)
                 it("유저를 조회 한다") {
-                    shouldNotThrowAny { followService.searchByFollowerNickname(TEST_USER_ID, TEST_NICKNAME, TEST_DEFAULT_SIZE, null) }
+                    shouldNotThrowAny {
+                        followService.searchByFollowerNickname(
+                            TEST_OTHER_USER_ID,
+                            TEST_USER_ID,
+                            TEST_NICKNAME,
+                            TEST_DEFAULT_SIZE,
+                            null,
+                        )
+                    }
                 }
             }
         }

--- a/src/test/kotlin/kr/weit/odya/support/ParamFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/ParamFixtures.kt
@@ -10,6 +10,7 @@ const val LAST_ID_PARAM = "lastId"
 const val NICKNAME_PARAM = "nickname"
 const val PHONE_NUMBERS_PARAM = "phoneNumbers"
 const val PLACE_ID_PARAM = "placeId"
+const val USER_ID_PARAM = "userId"
 const val TEST_DEFAULT_PAGE = 0
 const val TEST_DEFAULT_SIZE = 10
 const val TEST_PAGE: Int = 1


### PR DESCRIPTION
### 개요
- 타인의 팔로잉 팔로워를 닉네임으로 검색하는 기능이 필요했다

### 변경사항
- 타인의 팔로잉 팔로워 중에 닉네임에 해당하는 유저 조회 API 추가

### 관련 지라 및 위키 링크
- [ODYA-255](https://weit.atlassian.net/browse/ODYA-255)

### 리뷰어에게 하고 싶은 말
- 지혜님이 제보주셔서 빠르게 처리했습니다! ㅋㅋㅋ
