### PR TITLE
ODYA-260 푸시 알림 톤앤 매너 맞추기

### DIFF
--- a/src/main/kotlin/kr/weit/odya/client/push/PushDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/client/push/PushDtos.kt
@@ -9,7 +9,34 @@ data class PushNotificationEvent(
     constructor(
         title: String,
         body: String,
-        token: String,
-        data: Map<String, String>,
-    ) : this(title, body, listOf(token), data)
+        tokens: List<String>,
+        userName: String,
+        eventType: NotificationEventType,
+        communityId: Long? = null,
+        travelJournalId: Long? = null,
+        content: String? = null,
+        followerId: Long? = null,
+    ) : this(
+        title = title,
+        body = body,
+        tokens = tokens,
+        data = mutableMapOf(
+            "userName" to userName,
+            "eventType" to eventType.name,
+        ).apply {
+            communityId?.toString()?.let { put("communityId", it) }
+            travelJournalId?.toString()?.let { put("travelJournalId", it) }
+            content?.let { put("content", it) }
+            followerId?.toString()?.let { put("followerId", it) }
+        },
+    )
+}
+
+enum class NotificationEventType {
+    COMMUNITY_COMMENT,
+    COMMUNITY_LIKE,
+    FOLLOWER_ADD,
+    FOLLOWING_COMMUNITY,
+    FOLLOWING_TRAVEL_JOURNAL,
+    TRAVEL_JOURNAL_TAG,
 }

--- a/src/main/kotlin/kr/weit/odya/service/CommunityService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/CommunityService.kt
@@ -2,6 +2,7 @@ package kr.weit.odya.service
 
 import jakarta.ws.rs.ForbiddenException
 import kr.weit.odya.client.GoogleMapsClient
+import kr.weit.odya.client.push.NotificationEventType
 import kr.weit.odya.client.push.PushNotificationEvent
 import kr.weit.odya.domain.community.Community
 import kr.weit.odya.domain.community.CommunityContentImage
@@ -389,7 +390,9 @@ class CommunityService(
                 title = "피드 알림",
                 body = "${user.nickname}님이 피드를 작성했어요!",
                 tokens = fcmTokens,
-                data = mapOf("communityId" to community.id.toString()),
+                userName = user.nickname,
+                eventType = NotificationEventType.FOLLOWING_COMMUNITY,
+                communityId = community.id,
             ),
         )
     }

--- a/src/main/kotlin/kr/weit/odya/service/FollowService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/FollowService.kt
@@ -1,5 +1,6 @@
 package kr.weit.odya.service
 
+import kr.weit.odya.client.push.NotificationEventType
 import kr.weit.odya.client.push.PushNotificationEvent
 import kr.weit.odya.domain.follow.Follow
 import kr.weit.odya.domain.follow.FollowRepository
@@ -54,9 +55,11 @@ class FollowService(
         eventPublisher.publishEvent(
             PushNotificationEvent(
                 title = "팔로우 알림",
-                body = "${follower.nickname}님이 팔로우 했어요!",
-                token = token,
-                data = mapOf("followerId" to follower.id.toString()),
+                body = "${follower.nickname}님이 회원님을 팔로우했습니다",
+                tokens = listOf(token),
+                userName = follower.nickname,
+                eventType = NotificationEventType.FOLLOWER_ADD,
+                followerId = follower.id,
             ),
         )
     }

--- a/src/main/kotlin/kr/weit/odya/service/TravelJournalService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/TravelJournalService.kt
@@ -3,6 +3,7 @@ package kr.weit.odya.service
 import com.google.maps.model.PlaceDetails
 import jakarta.ws.rs.ForbiddenException
 import kr.weit.odya.client.GoogleMapsClient
+import kr.weit.odya.client.push.NotificationEventType
 import kr.weit.odya.client.push.PushNotificationEvent
 import kr.weit.odya.domain.community.CommunityRepository
 import kr.weit.odya.domain.contentimage.ContentImage
@@ -562,7 +563,9 @@ class TravelJournalService(
                     title = "같이간 친구 알림",
                     body = "${user.nickname}님이 여행 일지에 같이간 친구로 등록했어요!",
                     tokens = fcmTokens,
-                    data = mapOf("travelJournalId" to travelJournal.id.toString()),
+                    userName = user.nickname,
+                    eventType = NotificationEventType.TRAVEL_JOURNAL_TAG,
+                    travelJournalId = travelJournal.id,
                 )
             },
         )
@@ -573,7 +576,9 @@ class TravelJournalService(
                 title = "여행일지 알림",
                 body = "${user.nickname}님이 여행 일지를 작성했어요!",
                 tokens = followRepository.getFollowerFcmTokens(user.id),
-                data = mapOf("travelJournalId" to travelJournal.id.toString()),
+                userName = user.nickname,
+                eventType = NotificationEventType.FOLLOWING_TRAVEL_JOURNAL,
+                travelJournalId = travelJournal.id,
             ),
         )
     }

--- a/src/test/kotlin/kr/weit/odya/service/CommunityCommentServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/CommunityCommentServiceTest.kt
@@ -31,6 +31,7 @@ import kr.weit.odya.support.createCommunityComment
 import kr.weit.odya.support.createCommunityCommentRequest
 import kr.weit.odya.support.createMockCommunityComment
 import kr.weit.odya.support.createUser
+import org.springframework.context.ApplicationEventPublisher
 
 class CommunityCommentServiceTest : DescribeSpec(
     {
@@ -39,12 +40,14 @@ class CommunityCommentServiceTest : DescribeSpec(
         val userRepository: UserRepository = mockk<UserRepository>()
         val fileService: FileService = mockk<FileService>()
         val followRepository: FollowRepository = mockk<FollowRepository>()
+        val eventPublisher: ApplicationEventPublisher = mockk<ApplicationEventPublisher>()
         val communityCommentService = CommunityCommentService(
             communityRepository,
             communityCommentRepository,
             userRepository,
             fileService,
             followRepository,
+            eventPublisher,
         )
 
         describe("createCommunityComment") {

--- a/src/test/kotlin/kr/weit/odya/service/CommunityLikeServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/CommunityLikeServiceTest.kt
@@ -19,13 +19,15 @@ import kr.weit.odya.support.TEST_USER_ID
 import kr.weit.odya.support.createCommunity
 import kr.weit.odya.support.createCommunityLike
 import kr.weit.odya.support.createUser
+import org.springframework.context.ApplicationEventPublisher
 
 class CommunityLikeServiceTest : DescribeSpec(
     {
         val communityLikeRepository = mockk<CommunityLikeRepository>()
         val communityRepository = mockk<CommunityRepository>()
         val userRepository = mockk<UserRepository>()
-        val communityLikeService = CommunityLikeService(communityLikeRepository, communityRepository, userRepository)
+        val eventPublisher = mockk<ApplicationEventPublisher>()
+        val communityLikeService = CommunityLikeService(communityLikeRepository, communityRepository, userRepository,eventPublisher)
 
         describe("increaseCommunityLikeCount") {
             context("유효한 요청이 주어지는 경우") {


### PR DESCRIPTION
### 개요
- 현재 기획이된 푸시의 멘트가 지금 구현된 멘트와 다르다
- 일부 누락된 푸시알림이 있었다

### 변경사항
- 푸시 알림의 톤앤 매너를 맞춘다
- 푸시 알림 추가

### 관련 지라 및 위키 링크
- [ODYA-260](https://weit.atlassian.net/browse/ODYA-260)

### 리뷰어에게 하고 싶은 말
- 기획이 달라진건지 제가 처음에 잘못 작업을 한건지 멘트가 뭔가 진중해졌네요 ㅋㅋㅋ
- 그리고 빠진 푸시 알림의 경우의 수가 있는것 같아서 같이 작업했습니다~!
