### PR TITLE
ODYA-199 여행일지 콘텐츠 추가 API

### DIFF
--- a/src/docs/asciidoc/travelJournal.adoc
+++ b/src/docs/asciidoc/travelJournal.adoc
@@ -211,7 +211,6 @@ operation::travel-journal-controller-test/get-tagged-travel-journals-fail-invali
 
 operation::travel-journal-controller-test/get-tagged-travel-journals-fail-invalid-token[snippets='http-request,request-headers,query-parameters,http-response']
 
-
 [[여행일지수정-API]]
 == *8. 여행 일지 수정 API*
 
@@ -282,86 +281,117 @@ operation::travel-journal-controller-test/travel-journal-content-update-fail-not
 
 operation::travel-journal-controller-test/travel-journal-content-update-fail-invalid-token[snippets='http-request,request-headers,path-parameters,request-parts,http-response']
 
-[[여행일지-공개범위-수정-API]]
-== *10. 여행 일지 공개 범위 수정 API*
+[[여행일지콘텐츠수정-API]]
+== *10. 여행 일지 콘텐츠 추가 API*
 
 === *10-1 성공*
 
+operation::travel-journal-controller-test/add-travel-journals-content-success[snippets='http-request,request-headers,path-parameters,request-parts,http-response']
+
+=== *10-2 실패 - 여행일지 작성자가 아닌 경우*
+
+operation::travel-journal-controller-test/add-travel-journals-content-fail-not-same-user[snippets='http-request,request-headers,path-parameters,request-parts,http-response']
+
+=== *10-3 실패 - 여행일지 콘텐츠 이미지가 225개를 넘어가는 경우*
+
+operation::travel-journal-controller-test/add-travel-journals-content-fail-over-max-image-count[snippets='http-request,request-headers,path-parameters,request-parts,http-response']
+
+=== *10-4 실패 - 요청 여행일지 콘텐츠 이미지 이름과 이미지 파일의 이름이 다른 경우*
+
+operation::travel-journal-controller-test/add-travel-journals-content-fail-not-same-image-name[snippets='http-request,request-headers,path-parameters,request-parts,http-response']
+
+=== *10-5 실패 - 여행 콘텐츠 일자가 여행 시작일과 종료일 사이에 없는 경우*
+
+operation::travel-journal-controller-test/add-travel-journals-content-fail-travel-date-not-between-start-date-and-end-date[snippets='http-request,request-headers,path-parameters,request-parts,http-response']
+
+=== *10-6 실패 - 요청 여행일지 콘텐츠의 위도 개수와 경도 개수가 다른 경우*
+
+operation::travel-journal-controller-test/add-travel-journals-content-fail-not-same-size-of-latitudes-and-longitudes[snippets='http-request,request-headers,path-parameters,request-parts,http-response']
+
+=== *10-7 실패 - 유효하지 않은 토큰일 경우*
+
+operation::travel-journal-controller-test/add-travel-journals-content-fail-invalid-token[snippets='http-request,request-headers,path-parameters,request-parts,http-response']
+
+[[여행일지-공개범위-수정-API]]
+== *11. 여행 일지 공개 범위 수정 API*
+
+=== *11-1 성공*
+
 operation::travel-journal-controller-test/travel-journals-visibility-update-success[snippets='http-request,request-headers,path-parameters,request-body,http-response']
 
-=== *10-2 실패 - 유효하지 않은 여행일지 id인 경우*
+=== *11-2 실패 - 유효하지 않은 여행일지 id인 경우*
 
 operation::travel-journal-controller-test/travel-journals-visibility-update-fail-invalid-travel-journal-id[snippets='http-request,request-headers,path-parameters,request-body,http-response']
 
-=== *10-3 실패 - 존재하지 않는 여행일지 id인 경우*
+=== *11-3 실패 - 존재하지 않는 여행일지 id인 경우*
 
 operation::travel-journal-controller-test/travel-journals-visibility-update-fail-not-found-travel-journal[snippets='http-request,request-headers,path-parameters,request-body,http-response']
 
-=== *10-4 실패 - 커뮤니티에 연결된 여행일지를 비공개로 바꾸려고 한 경우*
+=== *11-4 실패 - 커뮤니티에 연결된 여행일지를 비공개로 바꾸려고 한 경우*
 
 operation::travel-journal-controller-test/travel-journals-visibility-update-fail-community-connected[snippets='http-request,request-headers,path-parameters,request-body,http-response']
 
-=== *10-5 실패 - 작성자와 요청자가 다른 경우*
+=== *11-5 실패 - 작성자와 요청자가 다른 경우*
 
 operation::travel-journal-controller-test/travel-journals-visibility-update-fail-not-same-user[snippets='http-request,request-headers,path-parameters,request-body,http-response']
 
-=== *10-6 실패 - 유효하지 않은 토큰일 경우*
+=== *11-6 실패 - 유효하지 않은 토큰일 경우*
 
 operation::travel-journal-controller-test/travel-journals-visibility-update-fail-invalid-token[snippets='http-request,request-headers,path-parameters,request-body,http-response']
 
 [[여행일지삭제-API]]
-== *11. 여행 일지 삭제 API*
+== *12. 여행 일지 삭제 API*
 
-=== *11-1 성공*
+=== *12-1 성공*
 
 operation::travel-journal-controller-test/travel-journals-delete-success[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *11-2 실패 - 작성자와 요청자가 다른 경우*
+=== *12-2 실패 - 작성자와 요청자가 다른 경우*
 
 operation::travel-journal-controller-test/travel-journals-delete-fail-not-same-user[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *11-3 실패 - 유효하지 않은 토큰일 경우*
+=== *12-3 실패 - 유효하지 않은 토큰일 경우*
 
 operation::travel-journal-controller-test/travel-journals-delete-fail-invalid-token[snippets='http-request,request-headers,path-parameters,http-response']
 
 [[여행일지콘텐츠삭제-API]]
-== *12. 여행 일지 콘텐츠 삭제 API*
+== *13. 여행 일지 콘텐츠 삭제 API*
 
-=== *12-1 성공*
+=== *13-1 성공*
 
 operation::travel-journal-controller-test/travel-journal-content-delete-success[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *12-2 실패 - 작성자와 요청자가 다른 경우*
+=== *13-2 실패 - 작성자와 요청자가 다른 경우*
 
 operation::travel-journal-controller-test/travel-journal-content-delete-fail-not-same-user[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *12-3 실패 - 여행 일지 콘텐츠 아이디와 일치하는 여행 일지 콘텐츠가 없는 경우*
+=== *13-3 실패 - 여행 일지 콘텐츠 아이디와 일치하는 여행 일지 콘텐츠가 없는 경우*
 
 operation::travel-journal-controller-test/travel-journal-content-delete-fail-not-found[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *12-4 실패 - 유효하지 않은 토큰일 경우*
+=== *13-4 실패 - 유효하지 않은 토큰일 경우*
 
 operation::travel-journal-controller-test/travel-journal-content-delete-fail-invalid-token[snippets='http-request,request-headers,path-parameters,http-response']
 
 [[여행일지같이간친구삭제-API]]
-== *13. 여행 일지 같이 간 친구 삭제 API*
+== *14. 여행 일지 같이 간 친구 삭제 API*
 
-=== *13-1 성공*
+=== *14-1 성공*
 
 operation::travel-journal-controller-test/travel-journal-remove-travel-companion-success[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *13-2 실패 - 양수가 아닌 여행 일지 ID가 들어온 경우*
+=== *14-2 실패 - 양수가 아닌 여행 일지 ID가 들어온 경우*
 
 operation::travel-journal-controller-test/travel-journal-remove-travel-companion-fail-invalid-id[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *13-3 실패 - 해당 여행일지의 같이 간 친구를 처리할 권한이 없는 경우*
+=== *14-3 실패 - 해당 여행일지의 같이 간 친구를 처리할 권한이 없는 경우*
 
 operation::travel-journal-controller-test/travel-journal-remove-travel-companion-fail-no-permission[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *13-4 실패 - 존재하지 않는 유저ID가 들어온 경우*
+=== *14-4 실패 - 존재하지 않는 유저ID가 들어온 경우*
 
 operation::travel-journal-controller-test/travel-journal-remove-travel-companion-fail-not-found[snippets='http-request,request-headers,path-parameters,http-response']
 
-=== *13-5 실패 - 유효하지 않은 토큰일 경우*
+=== *14-5 실패 - 유효하지 않은 토큰일 경우*
 
 operation::travel-journal-controller-test/travel-journal-remove-travel-companion-fail-invalid-token[snippets='http-request,request-headers,path-parameters,http-response']

--- a/src/main/kotlin/kr/weit/odya/controller/TravelJournalController.kt
+++ b/src/main/kotlin/kr/weit/odya/controller/TravelJournalController.kt
@@ -8,6 +8,7 @@ import kr.weit.odya.security.LoginUserId
 import kr.weit.odya.service.TravelJournalService
 import kr.weit.odya.service.dto.SliceResponse
 import kr.weit.odya.service.dto.TaggedTravelJournalResponse
+import kr.weit.odya.service.dto.TravelJournalContentRequest
 import kr.weit.odya.service.dto.TravelJournalContentUpdateRequest
 import kr.weit.odya.service.dto.TravelJournalRequest
 import kr.weit.odya.service.dto.TravelJournalResponse
@@ -15,6 +16,7 @@ import kr.weit.odya.service.dto.TravelJournalSummaryResponse
 import kr.weit.odya.service.dto.TravelJournalUpdateRequest
 import kr.weit.odya.service.dto.TravelJournalVisibilityUpdateRequest
 import kr.weit.odya.support.validator.NullOrNotBlank
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -219,6 +221,43 @@ class TravelJournalController(private val travelJournalService: TravelJournalSer
         return ResponseEntity.noContent().build()
     }
 
+    @PostMapping(path = ["/{travelJournalId}"], consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun addTravelJournalContent(
+        @Positive(message = "travelJournalId는 0보다 커야합니다.")
+        @PathVariable("travelJournalId")
+        travelJournalId: Long,
+        @LoginUserId userId: Long,
+        @RequestPart("travel-journal-content")
+        travelJournalContentRequest: TravelJournalContentRequest,
+        @Size(min = 1, max = 15, message = "이미지는 최소 1개, 최대 15개까지 업로드할 수 있습니다.")
+        @RequestPart("travel-journal-content-image")
+        images: List<MultipartFile>,
+    ): ResponseEntity<Void> {
+        val imageMap = travelJournalService.getImageMap(images)
+        travelJournalService.validateTravelJournalContentRequest(
+            travelJournalId,
+            userId,
+            travelJournalContentRequest,
+            imageMap,
+        )
+        val imageNamePairs = travelJournalService.uploadTravelContentImages(
+            travelJournalContentRequest.contentImageNames,
+            imageMap,
+        )
+        val placeDetailsMap =
+            travelJournalService.getPlaceDetailsMap(
+                travelJournalContentRequest.placeId?.let { setOf(it) }
+                    ?: emptySet(),
+            )
+        travelJournalService.addTravelJournalContent(
+            travelJournalId,
+            travelJournalContentRequest,
+            imageNamePairs,
+            placeDetailsMap,
+        )
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
     @PatchMapping("/{travelJournalId}/visibility")
     fun updateTravelJournalVisibility(
         @Positive(message = "travelJournalId는 0보다 커야합니다.")
@@ -229,7 +268,11 @@ class TravelJournalController(private val travelJournalService: TravelJournalSer
         @RequestBody
         travelJournalVisibilityUpdateRequest: TravelJournalVisibilityUpdateRequest,
     ): ResponseEntity<Void> {
-        travelJournalService.updateTravelJournalVisibility(travelJournalId, userId, travelJournalVisibilityUpdateRequest)
+        travelJournalService.updateTravelJournalVisibility(
+            travelJournalId,
+            userId,
+            travelJournalVisibilityUpdateRequest,
+        )
         return ResponseEntity.noContent().build()
     }
 

--- a/src/main/kotlin/kr/weit/odya/domain/traveljournal/TravelJournal.kt
+++ b/src/main/kotlin/kr/weit/odya/domain/traveljournal/TravelJournal.kt
@@ -12,6 +12,7 @@ import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import kr.weit.odya.domain.user.User
@@ -58,6 +59,7 @@ class TravelJournal(
     val travelCompanions: List<TravelCompanion>
         get() = mutableTravelCompanions
 
+    @OrderBy("travel_date ASC")
     @OneToMany(cascade = [CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE], orphanRemoval = true)
     @JoinColumn(name = "travel_journal_id", nullable = false, updatable = false, columnDefinition = "NUMERIC(19, 0)")
     private val mutableTravelJournalContents: MutableList<TravelJournalContent> = travelJournalContents.toMutableList()
@@ -86,5 +88,9 @@ class TravelJournal(
 
     fun addTravelCompanions(travelCompanions: List<TravelCompanion>) {
         mutableTravelCompanions.addAll(travelCompanions)
+    }
+
+    fun addTravelJournalContent(travelJournalContent: TravelJournalContent) {
+        mutableTravelJournalContents.add(travelJournalContent)
     }
 }

--- a/src/main/resources/db/migration/V33__add_travel_journal_content_index.sql
+++ b/src/main/resources/db/migration/V33__add_travel_journal_content_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX travel_journal_content_travel_travel_date_index ON travel_journal_content (travel_date);

--- a/src/test/kotlin/kr/weit/odya/controller/FavoritePlaceControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/FavoritePlaceControllerTest.kt
@@ -62,711 +62,727 @@ class FavoritePlaceControllerTest(
     @MockkBean private val favoritePlaceService: FavoritePlaceService,
     private val context: WebApplicationContext,
 ) : DescribeSpec(
-        {
-            val restDocumentation = ManualRestDocumentation()
-            val restDocMockMvc = RestDocsHelper.generateRestDocMockMvc(context, restDocumentation)
+    {
+        val restDocumentation = ManualRestDocumentation()
+        val restDocMockMvc = RestDocsHelper.generateRestDocMockMvc(context, restDocumentation)
 
-            beforeEach {
-                restDocumentation.beforeTest(javaClass, it.name.testName)
+        beforeEach {
+            restDocumentation.beforeTest(javaClass, it.name.testName)
+        }
+
+        describe("POST /api/v1/favorite-places") {
+            val targetUri = "/api/v1/favorite-places"
+            context("유효한 요청 데이터가 전달되면") {
+                val request = createFavoritePlaceRequest()
+                every { favoritePlaceService.createFavoritePlace(TEST_USER_ID, createFavoritePlaceRequest()) } just Runs
+                it("201를 반환한다.") {
+                    restDocMockMvc.post(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        jsonContent(request)
+                    }.andExpect {
+                        status { isCreated() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-create-success",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            requestBody(
+                                "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
+                            ),
+                        )
+                    }
+                }
             }
 
-            describe("POST /api/v1/favorite-places") {
-                val targetUri = "/api/v1/favorite-places"
-                context("유효한 요청 데이터가 전달되면") {
-                    val request = createFavoritePlaceRequest()
-                    every { favoritePlaceService.createFavoritePlace(TEST_USER_ID, createFavoritePlaceRequest()) } just Runs
-                    it("201를 반환한다.") {
-                        restDocMockMvc.post(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            jsonContent(request)
-                        }.andExpect {
-                            status { isCreated() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-create-success",
+            context("유효한 토큰이면서 장소 ID가 빈 문자열이면") {
+                val request = createFavoritePlaceRequest().copy(placeId = " ")
+                it("400를 반환한다.") {
+                    restDocMockMvc.post(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        jsonContent(request)
+                    }.andExpect {
+                        status { isBadRequest() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-create-failed-empty-place-id",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            requestBody(
+                                "placeId" type JsonFieldType.STRING description "공백인 장소 ID" example """ """,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("가입되어 있지 않은 USERID이 주어지는 경우") {
+                val request = createFavoritePlaceRequest()
+                it("401를 반환한다.") {
+                    restDocMockMvc.post(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN)
+                        jsonContent(request)
+                    }.andExpect {
+                        status { isUnauthorized() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-create-failed-not-exist-user-id",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            requestBody(
+                                "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효한 토큰이지만, 이미 관심 장소인 경우") {
+                val request = createFavoritePlaceRequest()
+                every {
+                    favoritePlaceService.createFavoritePlace(TEST_USER_ID, createFavoritePlaceRequest())
+                } throws ExistResourceException(EXIST_FAVORITE_PLACE_ERROR_MESSAGE)
+                it("409를 반환한다.") {
+                    restDocMockMvc.post(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                        jsonContent(request)
+                    }.andExpect {
+                        status { isConflict() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-create-failed-already-exist-favorite-place",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
+                            requestBody(
+                                "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            context("유효하지 않은 토큰이 전달되면") {
+                val request = createFavoritePlaceRequest()
+                it("401를 반환한다.") {
+                    restDocMockMvc.post(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                        jsonContent(request)
+                    }.andExpect {
+                        status { isUnauthorized() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-create-failed-invalid-token",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                            ),
+                            requestBody(
+                                "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+
+        describe("DELETE /api/v1/favorite-places/{id}") {
+            val targetUri = "/api/v1/favorite-places/{id}"
+            context("유효한 요청 데이터가 전달되면") {
+                every { favoritePlaceService.deleteFavoritePlace(TEST_USER_ID, TEST_FAVORITE_PLACE_ID) } just Runs
+                it("204를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .delete(targetUri, TEST_FAVORITE_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    ).andExpect(status().isNoContent)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-delete-success",
+                                pathParameters(
+                                    "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
+                                ),
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                                requestBody(
-                                    "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
-                                ),
-                            )
-                        }
-                    }
+                            ),
+                        )
                 }
+            }
 
-                context("유효한 토큰이면서 장소 ID가 빈 문자열이면") {
-                    val request = createFavoritePlaceRequest().copy(placeId = " ")
-                    it("400를 반환한다.") {
-                        restDocMockMvc.post(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            jsonContent(request)
-                        }.andExpect {
-                            status { isBadRequest() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-create-failed-empty-place-id",
+            context("양수가 아닌 관심 장소 ID인 경우") {
+                it("400를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .delete(targetUri, TEST_INVALID_FAVORITE_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-delete-failed-invalid-favorite-place-id",
+                                pathParameters(
+                                    "id" pathDescription "양수가 아닌 관심 장소 ID" example TEST_INVALID_FAVORITE_PLACE_ID,
+                                ),
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                                requestBody(
-                                    "placeId" type JsonFieldType.STRING description "공백인 장소 ID" example """ """,
-                                ),
-                            )
-                        }
-                    }
+                            ),
+                        )
                 }
+            }
 
-                context("가입되어 있지 않은 USERID이 주어지는 경우") {
-                    val request = createFavoritePlaceRequest()
-                    it("401를 반환한다.") {
-                        restDocMockMvc.post(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN)
-                            jsonContent(request)
-                        }.andExpect {
-                            status { isUnauthorized() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-create-failed-not-exist-user-id",
+            context("가입되어 있지 않은 USERID이 주어지는 경우") {
+                it("401를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .delete(targetUri, TEST_FAVORITE_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN),
+                    ).andExpect(status().isUnauthorized)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-delete-failed-not-exist-user-id",
+                                pathParameters(
+                                    "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
+                                ),
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                                requestBody(
-                                    "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
-                                ),
-                            )
-                        }
-                    }
+                            ),
+                        )
                 }
+            }
 
-                context("유효한 토큰이지만, 이미 관심 장소인 경우") {
-                    val request = createFavoritePlaceRequest()
-                    every {
-                        favoritePlaceService.createFavoritePlace(TEST_USER_ID, createFavoritePlaceRequest())
-                    } throws ExistResourceException(EXIST_FAVORITE_PLACE_ERROR_MESSAGE)
-                    it("409를 반환한다.") {
-                        restDocMockMvc.post(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                            jsonContent(request)
-                        }.andExpect {
-                            status { isConflict() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-create-failed-already-exist-favorite-place",
+            context("유효한 토큰이지만, 관심 장소가 아닌 경우") {
+                every {
+                    favoritePlaceService.deleteFavoritePlace(TEST_USER_ID, TEST_EXIST_FAVORITE_PLACE_ID)
+                } throws NoSuchElementException(NOT_FOUND_FAVORITE_PLACE_ERROR_MESSAGE)
+                it("404를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .delete(targetUri, TEST_EXIST_FAVORITE_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    ).andExpect(status().isNotFound)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-delete-failed-not-exist-favorite-place-id",
+                                pathParameters(
+                                    "id" pathDescription "존재하지 않는 관심 장소 ID" example TEST_EXIST_FAVORITE_PLACE_ID,
+                                ),
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                                requestBody(
-                                    "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
-                                ),
-                            )
-                        }
-                    }
+                            ),
+                        )
                 }
+            }
 
-                context("유효하지 않은 토큰이 전달되면") {
-                    val request = createFavoritePlaceRequest()
-                    it("401를 반환한다.") {
-                        restDocMockMvc.post(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
-                            jsonContent(request)
-                        }.andExpect {
-                            status { isUnauthorized() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-create-failed-invalid-token",
+            context("유효하지 않은 토큰이 전달되면") {
+                it("401를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .delete(targetUri, TEST_FAVORITE_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
+                    ).andExpect(status().isUnauthorized)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-delete-failed-invalid-token",
+                                pathParameters(
+                                    "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
+                                ),
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
                                 ),
-                                requestBody(
-                                    "placeId" type JsonFieldType.STRING description "장소 ID" example TEST_PLACE_ID,
-                                ),
-                            )
-                        }
-                    }
+                            ),
+                        )
                 }
             }
+        }
 
-            describe("DELETE /api/v1/favorite-places/{id}") {
-                val targetUri = "/api/v1/favorite-places/{id}"
-                context("유효한 요청 데이터가 전달되면") {
-                    every { favoritePlaceService.deleteFavoritePlace(TEST_USER_ID, TEST_FAVORITE_PLACE_ID) } just Runs
-                    it("204를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .delete(targetUri, TEST_FAVORITE_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                        ).andExpect(status().isNoContent)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-delete-success",
-                                    pathParameters(
-                                        "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
+        describe("GET /api/v1/favorite-places/{placeId}") {
+            val targetUri = "/api/v1/favorite-places/{placeId}"
+            context("유효한 요청 데이터가 전달되면") {
+                every { favoritePlaceService.getFavoritePlace(TEST_USER_ID, TEST_PLACE_ID) } returns true
+                it("200를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    ).andExpect(status().isOk)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-check-success",
+                                pathParameters(
+                                    "placeId" pathDescription "장소 ID" example TEST_PLACE_ID,
                                 ),
-                            )
-                    }
-                }
-
-                context("양수가 아닌 관심 장소 ID인 경우") {
-                    it("400를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .delete(targetUri, TEST_INVALID_FAVORITE_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-delete-failed-invalid-favorite-place-id",
-                                    pathParameters(
-                                        "id" pathDescription "양수가 아닌 관심 장소 ID" example TEST_INVALID_FAVORITE_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("가입되어 있지 않은 USERID이 주어지는 경우") {
-                    it("401를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .delete(targetUri, TEST_FAVORITE_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_NOT_EXIST_USER_ID_TOKEN),
-                        ).andExpect(status().isUnauthorized)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-delete-failed-not-exist-user-id",
-                                    pathParameters(
-                                        "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 토큰이지만, 관심 장소가 아닌 경우") {
-                    every {
-                        favoritePlaceService.deleteFavoritePlace(TEST_USER_ID, TEST_EXIST_FAVORITE_PLACE_ID)
-                    } throws NoSuchElementException(NOT_FOUND_FAVORITE_PLACE_ERROR_MESSAGE)
-                    it("404를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .delete(targetUri, TEST_EXIST_FAVORITE_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                        ).andExpect(status().isNotFound)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-delete-failed-not-exist-favorite-place-id",
-                                    pathParameters(
-                                        "id" pathDescription "존재하지 않는 관심 장소 ID" example TEST_EXIST_FAVORITE_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효하지 않은 토큰이 전달되면") {
-                    it("401를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .delete(targetUri, TEST_FAVORITE_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
-                        ).andExpect(status().isUnauthorized)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-delete-failed-invalid-token",
-                                    pathParameters(
-                                        "id" pathDescription "관심 장소 ID" example TEST_FAVORITE_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-            }
-
-            describe("GET /api/v1/favorite-places/{placeId}") {
-                val targetUri = "/api/v1/favorite-places/{placeId}"
-                context("유효한 요청 데이터가 전달되면") {
-                    every { favoritePlaceService.getFavoritePlace(TEST_USER_ID, TEST_PLACE_ID) } returns true
-                    it("200를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                        ).andExpect(status().isOk)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-check-success",
-                                    pathParameters(
-                                        "placeId" pathDescription "장소 ID" example TEST_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("placeId가 공백인 경우") {
-                    it("400를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, " ")
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-check-failed-empty-place-id",
-                                    pathParameters(
-                                        "placeId" pathDescription "공백인 장소 ID" example " ",
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효하지 않은 토큰 전달되면") {
-                    it("401를 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_PLACE_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
-                        ).andExpect(status().isUnauthorized)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-check-failed-invalid-token",
-                                    pathParameters(
-                                        "placeId" pathDescription "장소 ID" example TEST_PLACE_ID,
-                                    ),
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                                    ),
-                                ),
-                            )
-                    }
-                }
-            }
-
-            describe("GET /api/v1/favorite-places/counts") {
-                val targetUri = "/api/v1/favorite-places/counts"
-                context("유효한 USERID가 전달되면") {
-                    every { favoritePlaceService.getFavoritePlaceCount(TEST_USER_ID) } returns TEST_FAVORITE_PLACE_COUNT
-                    it("관심장소 수를 출력한다.") {
-                        restDocMockMvc.get(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                        }.andExpect {
-                            status { isOk() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-count-success",
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
                                 ),
-                            )
-                        }
-                    }
+                            ),
+                        )
                 }
+            }
 
-                context("유효하지않은 토큰이 전달되면") {
-                    it("401을 출력한다.") {
-                        restDocMockMvc.get(targetUri) {
-                            header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
-                        }.andExpect {
-                            status { isUnauthorized() }
-                        }.andDo {
-                            createDocument(
-                                "favorite-place-count-failed-invalid-token",
+            context("placeId가 공백인 경우") {
+                it("400를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, " ")
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-check-failed-empty-place-id",
+                                pathParameters(
+                                    "placeId" pathDescription "공백인 장소 ID" example " ",
+                                ),
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효하지 않은 토큰 전달되면") {
+                it("401를 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_PLACE_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN),
+                    ).andExpect(status().isUnauthorized)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-check-failed-invalid-token",
+                                pathParameters(
+                                    "placeId" pathDescription "장소 ID" example TEST_PLACE_ID,
+                                ),
                                 requestHeaders(
                                     HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
                                 ),
-                            )
-                        }
-                    }
-                }
-            }
-
-            describe("GET /api/v1/favorite-places/list") {
-                val targetUri = "/api/v1/favorite-places/list"
-                context("유효한 USERID와 size,sortType,lastId가 전달되면") {
-                    val response = createSliceFavoritePlaceResponse()
-                    val content = response.content[0]
-                    every {
-                        favoritePlaceService.getMyFavoritePlaceList(TEST_USER_ID, TEST_SIZE, TEST_FAVORITE_PLACE_SORT_TYPE, TEST_LAST_ID)
-                    } returns createSliceFavoritePlaceResponse()
-                    it("관심장소 수를 출력한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(SIZE_PARAM, TEST_SIZE.toString())
-                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isOk)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-list-success",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                    responseBody(
-                                        "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
-                                        "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
-                                        "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
-                                        "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
-                                        "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 USERID만 전달되면") {
-                    val response = createSliceFavoritePlaceResponse()
-                    val content = response.content[0]
-                    every {
-                        favoritePlaceService.getMyFavoritePlaceList(TEST_USER_ID, TEST_DEFAULT_SIZE, TEST_FAVORITE_PLACE_SORT_TYPE, null)
-                    } returns createSliceFavoritePlaceResponse()
-                    it("관심장소 수를 출력한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
-                        ).andExpect(status().isOk)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-list-request-param-null-success",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example "null" isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example "null" isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example "null" isOptional true,
-                                    ),
-                                    responseBody(
-                                        "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
-                                        "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
-                                        "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
-                                        "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
-                                        "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 USERID와 양수가 아닌 size가 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
-                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-list-failed-invalid-size",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "양수가 아닌 츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 USERID와 정의하지 않은 정렬 기준이 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(SIZE_PARAM, TEST_SIZE.toString())
-                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_INVALID_SORT_TYPE)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-list-failed-invalid-sort-type",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "정의되지 않은 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_INVALID_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 USERID와 양수가 아닌 마지막 ID가 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(SIZE_PARAM, TEST_SIZE.toString())
-                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
-                                .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-list-failed-invalid-last-id",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "양수가 아닌 마지막 리스트 ID" example TEST_INVALID_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효하지 않은 토큰이 전달되면") {
-                    it("401을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
-                                .param(SIZE_PARAM, TEST_SIZE.toString())
-                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isUnauthorized)
-                            .andDo(
-                                createPathDocument(
-                                    "favorite-place-list-failed-invalid-token",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-            }
-
-            describe("GET /api/v1/favorite-places/list/{userId}") {
-                val targetUri = "/api/v1/favorite-places/list/{userId}"
-                context("유효한 USERID와 size,sortType,lastId가 전달되면") {
-                    val response = createSliceFavoritePlaceResponse()
-                    val content = response.content[0]
-                    every {
-                        favoritePlaceService.getFavoritePlaceList(TEST_USER_ID, TEST_USER_ID, TEST_DEFAULT_SIZE, TEST_FAVORITE_PLACE_SORT_TYPE, TEST_LAST_ID)
-                    } returns createSliceFavoritePlaceResponse()
-                    it("관심장소 리스트를 출력한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_USER_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                            ),
                         )
-                            .andExpect(status().isOk)
-                            .andDo(
-                                createPathDocument(
-                                    "other-favorite-place-list-success",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    pathParameters(
-                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                    responseBody(
-                                        "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
-                                        "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
-                                        "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
-                                        "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
-                                        "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
-                                    ),
-                                ),
-                            )
-                    }
                 }
+            }
+        }
 
-                context("양수가 아닌 USERID가 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_INVALID_USER_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+        describe("GET /api/v1/favorite-places/counts") {
+            val targetUri = "/api/v1/favorite-places/counts"
+            context("유효한 USERID가 전달되면") {
+                every { favoritePlaceService.getFavoritePlaceCount(TEST_USER_ID) } returns TEST_FAVORITE_PLACE_COUNT
+                it("관심장소 수를 출력한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                    }.andExpect {
+                        status { isOk() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-count-success",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                            ),
                         )
-                            .andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "other-favorite-place-list-failed-invalid-id",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    pathParameters(
-                                        "userId" pathDescription "양수가 아닌 USER ID" example TEST_INVALID_USER_ID,
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("양수가 아닌 size가 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_USER_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "other-favorite-place-list-failed-invalid-size",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    pathParameters(
-                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "양수가 아닌 츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 USERID와 정의하지 않은 정렬 기준이 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_USER_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_INVALID_SORT_TYPE)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "other-favorite-place-list-failed-invalid-sort-type",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    pathParameters(
-                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "정의되지 않은 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_INVALID_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효한 USERID와 양수가 아닌 마지막 ID가 전달되면") {
-                    it("400을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_USER_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
-                                .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
-                        ).andExpect(status().isBadRequest)
-                            .andDo(
-                                createPathDocument(
-                                    "other-favorite-place-list-failed-invalid-last-id",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                                    ),
-                                    pathParameters(
-                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "양수가 아닌 마지막 리스트 ID" example TEST_INVALID_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
-                    }
-                }
-
-                context("유효하지 않은 토큰이 전달되면") {
-                    it("401을 반환한다.") {
-                        restDocMockMvc.perform(
-                            RestDocumentationRequestBuilders
-                                .get(targetUri, TEST_USER_ID)
-                                .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
-                                .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
-                        ).andExpect(status().isUnauthorized)
-                            .andDo(
-                                createPathDocument(
-                                    "other-favorite-place-list-failed-invalid-token",
-                                    requestHeaders(
-                                        HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
-                                    ),
-                                    pathParameters(
-                                        "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
-                                    ),
-                                    queryParameters(
-                                        SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                        SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
-                                        LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                    ),
-                                ),
-                            )
                     }
                 }
             }
 
-            afterEach {
-                restDocumentation.afterTest()
+            context("유효하지않은 토큰이 전달되면") {
+                it("401을 출력한다.") {
+                    restDocMockMvc.get(targetUri) {
+                        header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                    }.andExpect {
+                        status { isUnauthorized() }
+                    }.andDo {
+                        createDocument(
+                            "favorite-place-count-failed-invalid-token",
+                            requestHeaders(
+                                HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                            ),
+                        )
+                    }
+                }
             }
-        },
-    )
+        }
+
+        describe("GET /api/v1/favorite-places/list") {
+            val targetUri = "/api/v1/favorite-places/list"
+            context("유효한 USERID와 size,sortType,lastId가 전달되면") {
+                val response = createSliceFavoritePlaceResponse()
+                val content = response.content[0]
+                every {
+                    favoritePlaceService.getMyFavoritePlaceList(
+                        TEST_USER_ID,
+                        TEST_SIZE,
+                        TEST_FAVORITE_PLACE_SORT_TYPE,
+                        TEST_LAST_ID,
+                    )
+                } returns createSliceFavoritePlaceResponse()
+                it("관심장소 수를 출력한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(SIZE_PARAM, TEST_SIZE.toString())
+                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isOk)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-list-success",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                                responseBody(
+                                    "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
+                                    "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
+                                    "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
+                                    "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
+                                    "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효한 USERID만 전달되면") {
+                val response = createSliceFavoritePlaceResponse()
+                val content = response.content[0]
+                every {
+                    favoritePlaceService.getMyFavoritePlaceList(
+                        TEST_USER_ID,
+                        TEST_DEFAULT_SIZE,
+                        TEST_FAVORITE_PLACE_SORT_TYPE,
+                        null,
+                    )
+                } returns createSliceFavoritePlaceResponse()
+                it("관심장소 수를 출력한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN),
+                    ).andExpect(status().isOk)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-list-request-param-null-success",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example "null" isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example "null" isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example "null" isOptional true,
+                                ),
+                                responseBody(
+                                    "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
+                                    "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
+                                    "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
+                                    "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
+                                    "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효한 USERID와 양수가 아닌 size가 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
+                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-list-failed-invalid-size",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "양수가 아닌 츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효한 USERID와 정의하지 않은 정렬 기준이 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(SIZE_PARAM, TEST_SIZE.toString())
+                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_INVALID_SORT_TYPE)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-list-failed-invalid-sort-type",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "정의되지 않은 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_INVALID_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효한 USERID와 양수가 아닌 마지막 ID가 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(SIZE_PARAM, TEST_SIZE.toString())
+                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
+                            .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-list-failed-invalid-last-id",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "양수가 아닌 마지막 리스트 ID" example TEST_INVALID_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효하지 않은 토큰이 전달되면") {
+                it("401을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                            .param(SIZE_PARAM, TEST_SIZE.toString())
+                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_SORT_TYPE.name)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isUnauthorized)
+                        .andDo(
+                            createPathDocument(
+                                "favorite-place-list-failed-invalid-token",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+        }
+
+        describe("GET /api/v1/favorite-places/list/{userId}") {
+            val targetUri = "/api/v1/favorite-places/list/{userId}"
+            context("유효한 USERID와 size,sortType,lastId가 전달되면") {
+                val response = createSliceFavoritePlaceResponse()
+                val content = response.content[0]
+                every {
+                    favoritePlaceService.getFavoritePlaceList(
+                        TEST_USER_ID,
+                        TEST_USER_ID,
+                        TEST_DEFAULT_SIZE,
+                        TEST_FAVORITE_PLACE_SORT_TYPE,
+                        TEST_LAST_ID,
+                    )
+                } returns createSliceFavoritePlaceResponse()
+                it("관심장소 리스트를 출력한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    )
+                        .andExpect(status().isOk)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-list-success",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                                responseBody(
+                                    "hasNext" type JsonFieldType.BOOLEAN description "데이터가 더 존재하는지 여부" example response.hasNext,
+                                    "content[].id" type JsonFieldType.NUMBER description "관심 장소 ID" example content.id,
+                                    "content[].placeId" type JsonFieldType.STRING description "장소 ID" example content.placeId,
+                                    "content[].userId" type JsonFieldType.NUMBER description "유저 ID" example content.userId,
+                                    "content[].isFavoritePlace" type JsonFieldType.BOOLEAN description "관심 장소 여부" example content.isFavoritePlace,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("양수가 아닌 USERID가 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_INVALID_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    )
+                        .andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-list-failed-invalid-id",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "양수가 아닌 USER ID" example TEST_INVALID_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_DEFAULT_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("양수가 아닌 size가 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-list-failed-invalid-size",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "양수가 아닌 츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효한 USERID와 정의하지 않은 정렬 기준이 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(SORT_TYPE_PARAM, TEST_FAVORITE_PLACE_INVALID_SORT_TYPE)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-list-failed-invalid-sort-type",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_INVALID_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "정의되지 않은 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_INVALID_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효한 USERID와 양수가 아닌 마지막 ID가 전달되면") {
+                it("400을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
+                            .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-list-failed-invalid-last-id",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "양수가 아닌 마지막 리스트 ID" example TEST_INVALID_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+
+            context("유효하지 않은 토큰이 전달되면") {
+                it("401을 반환한다.") {
+                    restDocMockMvc.perform(
+                        RestDocumentationRequestBuilders
+                            .get(targetUri, TEST_USER_ID)
+                            .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isUnauthorized)
+                        .andDo(
+                            createPathDocument(
+                                "other-favorite-place-list-failed-invalid-token",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "INVALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    "userId" pathDescription "조회할 USER ID" example TEST_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM pathDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                    SORT_TYPE_PARAM pathDescription "리스트 정렬기준(default=최신순)" example TEST_FAVORITE_PLACE_SORT_TYPE isOptional true,
+                                    LAST_ID_PARAM pathDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                ),
+                            ),
+                        )
+                }
+            }
+        }
+
+        afterEach {
+            restDocumentation.afterTest()
+        }
+    },
+)

--- a/src/test/kotlin/kr/weit/odya/controller/FollowControllerTest.kt
+++ b/src/test/kotlin/kr/weit/odya/controller/FollowControllerTest.kt
@@ -646,7 +646,15 @@ class FollowControllerTest(
             val targetUri = "/api/v1/follows/followings/search"
             context("유효한 토큰이면서, 가입된 사용자인 경우") {
                 val response = createFollowSlice()
-                every { followService.searchByFollowingNickname(TEST_USER_ID, TEST_USER_ID, TEST_NICKNAME, TEST_SIZE, TEST_LAST_ID) } returns response
+                every {
+                    followService.searchByFollowingNickname(
+                        TEST_USER_ID,
+                        TEST_USER_ID,
+                        TEST_NICKNAME,
+                        TEST_SIZE,
+                        TEST_LAST_ID,
+                    )
+                } returns response
                 it("200 응답한다.") {
                     restDocMockMvc.get(targetUri) {
                         header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
@@ -813,7 +821,15 @@ class FollowControllerTest(
             val targetUri = "/api/v1/follows/followers/search"
             context("유효한 토큰이면서, 가입된 사용자인 경우") {
                 val response = createFollowSlice()
-                every { followService.searchByFollowerNickname(TEST_USER_ID, TEST_USER_ID, TEST_NICKNAME, TEST_SIZE, TEST_LAST_ID) } returns response
+                every {
+                    followService.searchByFollowerNickname(
+                        TEST_USER_ID,
+                        TEST_USER_ID,
+                        TEST_NICKNAME,
+                        TEST_SIZE,
+                        TEST_LAST_ID,
+                    )
+                } returns response
                 it("200 응답한다.") {
                     restDocMockMvc.get(targetUri) {
                         header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
@@ -956,7 +972,15 @@ class FollowControllerTest(
             context("유효한 토큰이면서, 가입된 사용자인 경우") {
                 val response = createFollowSlice()
                 val content = response.content[0]
-                every { followService.searchByFollowingNickname(TEST_USER_ID, TEST_OTHER_USER_ID, TEST_NICKNAME, TEST_SIZE, TEST_LAST_ID) } returns response
+                every {
+                    followService.searchByFollowingNickname(
+                        TEST_USER_ID,
+                        TEST_OTHER_USER_ID,
+                        TEST_NICKNAME,
+                        TEST_SIZE,
+                        TEST_LAST_ID,
+                    )
+                } returns response
                 it("200 응답한다.") {
                     restDocMockMvc.perform(
                         RestDocumentationRequestBuilders.get(
@@ -965,9 +989,9 @@ class FollowControllerTest(
                         ).header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
                             .param(SIZE_PARAM, TEST_SIZE.toString())
                             .param(NICKNAME_PARAM, TEST_NICKNAME)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString())
-                        ).andExpect ( status().isOk() )
-                        .andDo (
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isOk())
+                        .andDo(
                             createPathDocument(
                                 "search-other-followings-success",
                                 requestHeaders(
@@ -992,50 +1016,50 @@ class FollowControllerTest(
                                     "content[].profile.profileColor.green" type JsonFieldType.NUMBER description "RGB GREEN" example content.profile.profileColor?.green isOptional true,
                                     "content[].profile.profileColor.blue" type JsonFieldType.NUMBER description "RGB BLUE" example content.profile.profileColor?.blue isOptional true,
                                 ),
-                            )
-                    )
+                            ),
+                        )
                 }
             }
 
             context("팔로잉 검색할 유저의 id가 음수인 경우") {
                 it("400 응답한다.") {
-                    restDocMockMvc.perform (
+                    restDocMockMvc.perform(
                         RestDocumentationRequestBuilders.get(targetUri, TEST_INVALID_USER_ID)
                             .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
                             .param(SIZE_PARAM, TEST_SIZE.toString())
                             .param(NICKNAME_PARAM, TEST_NICKNAME)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString())
-                        ).andExpect (status().isBadRequest())
-                        .andDo (
-                        createPathDocument(
-                            "search-other-followings-fail-invalid-user-id",
-                            requestHeaders(
-                                HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
-                            ),
-                            pathParameters(
-                                USER_ID_PARAM pathDescription "음수의 USER ID" example TEST_INVALID_USER_ID,
-                            ),
-                            queryParameters(
-                                SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
-                                LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
-                                NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(status().isBadRequest())
+                        .andDo(
+                            createPathDocument(
+                                "search-other-followings-fail-invalid-user-id",
+                                requestHeaders(
+                                    HttpHeaders.AUTHORIZATION headerDescription "VALID ID TOKEN",
+                                ),
+                                pathParameters(
+                                    USER_ID_PARAM pathDescription "음수의 USER ID" example TEST_INVALID_USER_ID,
+                                ),
+                                queryParameters(
+                                    SIZE_PARAM parameterDescription "츨력할 리스트 사이즈(default=10)" example TEST_SIZE isOptional true,
+                                    LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
+                                    NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
+                                ),
                             ),
                         )
-                )
                 }
             }
 
             context("유효한 토큰이면서, 닉네임이 없는 경우") {
                 it("400 응답한다.") {
-                    restDocMockMvc.perform (
+                    restDocMockMvc.perform(
                         RestDocumentationRequestBuilders.get(targetUri, TEST_OTHER_USER_ID)
                             .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
                             .param(SIZE_PARAM, TEST_SIZE.toString())
                             .param(LAST_ID_PARAM, TEST_LAST_ID.toString())
-                            .param(NICKNAME_PARAM, " ")
-                    ).andExpect (
-                        status().isBadRequest()
-                    ).andDo (
+                            .param(NICKNAME_PARAM, " "),
+                    ).andExpect(
+                        status().isBadRequest(),
+                    ).andDo(
                         createPathDocument(
                             "search-other-followings-fail-nickname-blank",
                             requestHeaders(
@@ -1049,22 +1073,22 @@ class FollowControllerTest(
                                 LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
                                 NICKNAME_PARAM parameterDescription "공백인 검색할 닉네임" example " ",
                             ),
-                        )
+                        ),
                     )
                 }
             }
 
             context("유효한 토큰이지만 조회할 마지막 ID가 양수가 아닌 경우") {
                 it("400 응답한다.") {
-                    restDocMockMvc.perform (
+                    restDocMockMvc.perform(
                         RestDocumentationRequestBuilders.get(targetUri, TEST_OTHER_USER_ID)
                             .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
                             .param(SIZE_PARAM, TEST_SIZE.toString())
                             .param(NICKNAME_PARAM, TEST_NICKNAME)
-                            .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString())
-                    ).andExpect (
-                        status().isBadRequest()
-                    ).andDo (
+                            .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
+                    ).andExpect(
+                        status().isBadRequest(),
+                    ).andDo(
                         createPathDocument(
                             "search-other-followings-fail-invalid-last-id",
                             requestHeaders(
@@ -1078,22 +1102,22 @@ class FollowControllerTest(
                                 LAST_ID_PARAM parameterDescription "양수가 아닌 마지막 데이터의 ID" example TEST_INVALID_LAST_ID isOptional true,
                                 NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
                             ),
-                        )
+                        ),
                     )
                 }
             }
 
             context("유효한 토큰이지만 size가 양수가 아닌 경우") {
                 it("400 응답한다.") {
-                    restDocMockMvc.perform (
+                    restDocMockMvc.perform(
                         RestDocumentationRequestBuilders.get(targetUri, TEST_OTHER_USER_ID)
                             .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
                             .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
                             .param(NICKNAME_PARAM, TEST_NICKNAME)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString())
-                    ).andExpect (
-                        status().isBadRequest()
-                    ).andDo (
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(
+                        status().isBadRequest(),
+                    ).andDo(
                         createPathDocument(
                             "search-other-followings-fail-invalid-size",
                             requestHeaders(
@@ -1107,22 +1131,22 @@ class FollowControllerTest(
                                 LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
                                 NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
                             ),
-                        )
+                        ),
                     )
                 }
             }
 
             context("유효하지 않은 토큰이면") {
                 it("401 응답한다.") {
-                    restDocMockMvc.perform (
+                    restDocMockMvc.perform(
                         RestDocumentationRequestBuilders.get(targetUri, TEST_OTHER_USER_ID)
                             .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
                             .param(SIZE_PARAM, TEST_SIZE.toString())
                             .param(NICKNAME_PARAM, TEST_NICKNAME)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString())
-                    ).andExpect (
-                        status().isUnauthorized()
-                    ).andDo (
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(
+                        status().isUnauthorized(),
+                    ).andDo(
                         createPathDocument(
                             "search-other-followings-fail-invalid-token",
                             requestHeaders(
@@ -1136,7 +1160,7 @@ class FollowControllerTest(
                                 LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example "null" isOptional true,
                                 NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
                             ),
-                        )
+                        ),
                     )
                 }
             }
@@ -1147,17 +1171,25 @@ class FollowControllerTest(
             context("유효한 토큰이면서, 가입된 사용자인 경우") {
                 val response = createFollowSlice()
                 val content = response.content[0]
-                every { followService.searchByFollowerNickname(TEST_USER_ID, TEST_OTHER_USER_ID, TEST_NICKNAME, TEST_SIZE, TEST_LAST_ID) } returns response
+                every {
+                    followService.searchByFollowerNickname(
+                        TEST_USER_ID,
+                        TEST_OTHER_USER_ID,
+                        TEST_NICKNAME,
+                        TEST_SIZE,
+                        TEST_LAST_ID,
+                    )
+                } returns response
                 it("200 응답한다.") {
-                    restDocMockMvc.perform (
+                    restDocMockMvc.perform(
                         RestDocumentationRequestBuilders.get(targetUri, TEST_OTHER_USER_ID)
                             .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
                             .param(SIZE_PARAM, TEST_SIZE.toString())
                             .param(NICKNAME_PARAM, TEST_NICKNAME)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString())
-                    ).andExpect (
-                        status().isOk()
-                    ).andDo (
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(
+                        status().isOk(),
+                    ).andDo(
                         createPathDocument(
                             "search-other-followers-success",
                             requestHeaders(
@@ -1182,22 +1214,22 @@ class FollowControllerTest(
                                 "content[].profile.profileColor.green" type JsonFieldType.NUMBER description "RGB GREEN" example content.profile.profileColor?.green isOptional true,
                                 "content[].profile.profileColor.blue" type JsonFieldType.NUMBER description "RGB BLUE" example content.profile.profileColor?.blue isOptional true,
                             ),
-                        )
+                        ),
                     )
                 }
             }
 
             context("팔로워 검색할 유저의 id가 음수인 경우") {
                 it("400 응답한다.") {
-                    restDocMockMvc.perform (
+                    restDocMockMvc.perform(
                         RestDocumentationRequestBuilders.get(targetUri, TEST_INVALID_USER_ID)
                             .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
                             .param(SIZE_PARAM, TEST_SIZE.toString())
                             .param(LAST_ID_PARAM, TEST_LAST_ID.toString())
-                            .param(NICKNAME_PARAM, TEST_NICKNAME)
-                    ).andExpect (
-                        status().isBadRequest()
-                    ).andDo (
+                            .param(NICKNAME_PARAM, TEST_NICKNAME),
+                    ).andExpect(
+                        status().isBadRequest(),
+                    ).andDo(
                         createPathDocument(
                             "search-other-followers-fail-invalid-user-id",
                             requestHeaders(
@@ -1211,7 +1243,7 @@ class FollowControllerTest(
                                 LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
                                 NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
                             ),
-                        )
+                        ),
                     )
                 }
             }
@@ -1223,10 +1255,10 @@ class FollowControllerTest(
                             .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
                             .param(SIZE_PARAM, TEST_SIZE.toString())
                             .param(NICKNAME_PARAM, " ")
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString())
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
                     ).andExpect(
-                        status().isBadRequest()
-                    ).andDo (
+                        status().isBadRequest(),
+                    ).andDo(
                         createPathDocument(
                             "search-other-followers-fail-nickname-blank",
                             requestHeaders(
@@ -1240,22 +1272,22 @@ class FollowControllerTest(
                                 LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
                                 NICKNAME_PARAM parameterDescription "공백인 검색할 닉네임" example " ",
                             ),
-                        )
+                        ),
                     )
                 }
             }
 
             context("유효한 토큰이지만 조회할 마지막 ID가 양수가 아닌 경우") {
                 it("400 응답한다.") {
-                    restDocMockMvc.perform (
+                    restDocMockMvc.perform(
                         RestDocumentationRequestBuilders.get(targetUri, TEST_OTHER_USER_ID)
                             .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
                             .param(SIZE_PARAM, TEST_SIZE.toString())
                             .param(NICKNAME_PARAM, TEST_NICKNAME)
-                            .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString())
-                        ).andExpect (
-                        status().isBadRequest()
-                    ).andDo (
+                            .param(LAST_ID_PARAM, TEST_INVALID_LAST_ID.toString()),
+                    ).andExpect(
+                        status().isBadRequest(),
+                    ).andDo(
                         createPathDocument(
                             "search-other-followers-fail-invalid-last-id",
                             requestHeaders(
@@ -1269,22 +1301,22 @@ class FollowControllerTest(
                                 LAST_ID_PARAM parameterDescription "양수가 아닌 마지막 데이터의 ID" example TEST_INVALID_LAST_ID isOptional true,
                                 NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
                             ),
-                        )
+                        ),
                     )
                 }
             }
 
             context("유효한 토큰이지만 size가 양수가 아닌 경우") {
                 it("400 응답한다.") {
-                    restDocMockMvc.perform (
+                    restDocMockMvc.perform(
                         RestDocumentationRequestBuilders.get(targetUri, TEST_OTHER_USER_ID)
                             .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_ID_TOKEN)
                             .param(SIZE_PARAM, TEST_INVALID_SIZE.toString())
                             .param(NICKNAME_PARAM, TEST_NICKNAME)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString())
-                        ).andExpect (
-                        status().isBadRequest()
-                    ).andDo (
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(
+                        status().isBadRequest(),
+                    ).andDo(
                         createPathDocument(
                             "search-other-followers-fail-invalid-size",
                             requestHeaders(
@@ -1298,22 +1330,22 @@ class FollowControllerTest(
                                 LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example TEST_LAST_ID isOptional true,
                                 NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
                             ),
-                        )
+                        ),
                     )
                 }
             }
 
             context("유효하지 않은 토큰이면") {
                 it("401 응답한다.") {
-                    restDocMockMvc.perform (
+                    restDocMockMvc.perform(
                         RestDocumentationRequestBuilders.get(targetUri, TEST_OTHER_USER_ID)
                             .header(HttpHeaders.AUTHORIZATION, TEST_BEARER_INVALID_ID_TOKEN)
                             .param(SIZE_PARAM, TEST_SIZE.toString())
                             .param(NICKNAME_PARAM, TEST_NICKNAME)
-                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString())
-                    ).andExpect (
-                        status().isUnauthorized()
-                    ).andDo (
+                            .param(LAST_ID_PARAM, TEST_LAST_ID.toString()),
+                    ).andExpect(
+                        status().isUnauthorized(),
+                    ).andDo(
                         createPathDocument(
                             "search-other-followers-fail-invalid-token",
                             requestHeaders(
@@ -1327,7 +1359,7 @@ class FollowControllerTest(
                                 LAST_ID_PARAM parameterDescription "마지막 리스트 ID" example "null" isOptional true,
                                 NICKNAME_PARAM parameterDescription "검색할 닉네임" example TEST_NICKNAME,
                             ),
-                        )
+                        ),
                     )
                 }
             }

--- a/src/test/kotlin/kr/weit/odya/service/CommunityLikeServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/CommunityLikeServiceTest.kt
@@ -27,7 +27,8 @@ class CommunityLikeServiceTest : DescribeSpec(
         val communityRepository = mockk<CommunityRepository>()
         val userRepository = mockk<UserRepository>()
         val eventPublisher = mockk<ApplicationEventPublisher>()
-        val communityLikeService = CommunityLikeService(communityLikeRepository, communityRepository, userRepository,eventPublisher)
+        val communityLikeService =
+            CommunityLikeService(communityLikeRepository, communityRepository, userRepository, eventPublisher)
 
         describe("increaseCommunityLikeCount") {
             context("유효한 요청이 주어지는 경우") {

--- a/src/test/kotlin/kr/weit/odya/service/TravelJournalServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/TravelJournalServiceTest.kt
@@ -43,6 +43,7 @@ import kr.weit.odya.support.TEST_FILE_AUTHENTICATED_URL
 import kr.weit.odya.support.TEST_GENERATED_FILE_NAME
 import kr.weit.odya.support.TEST_IMAGE_FILE_WEBP
 import kr.weit.odya.support.TEST_OTHER_IMAGE_FILE_WEBP
+import kr.weit.odya.support.TEST_OTHER_TRAVEL_JOURNAL_ID
 import kr.weit.odya.support.TEST_OTHER_USER_ID
 import kr.weit.odya.support.TEST_PLACE_ID
 import kr.weit.odya.support.TEST_TRAVEL_COMPANION_IDS
@@ -556,7 +557,9 @@ class TravelJournalServiceTest : DescribeSpec(
                 } returns listOf(TEST_TRAVEL_JOURNAL)
                 every { fileService.getPreAuthenticatedObjectUrl(any<String>()) } returns TEST_FILE_AUTHENTICATED_URL
                 every { followRepository.findFollowingIdsByFollowerId(TEST_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
-                every { travelJournalBookmarkRepository.getTravelJournalIds(TEST_USER_ID) } returns listOf(TEST_TRAVEL_JOURNAL_ID)
+                every { travelJournalBookmarkRepository.getTravelJournalIds(TEST_USER_ID) } returns listOf(
+                    TEST_TRAVEL_JOURNAL_ID,
+                )
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
                         travelJournalService.getTravelJournals(
@@ -583,7 +586,9 @@ class TravelJournalServiceTest : DescribeSpec(
                 } returns listOf(TEST_TRAVEL_JOURNAL)
                 every { fileService.getPreAuthenticatedObjectUrl(any<String>()) } returns TEST_FILE_AUTHENTICATED_URL
                 every { followRepository.findFollowingIdsByFollowerId(TEST_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
-                every { travelJournalBookmarkRepository.getTravelJournalIds(TEST_USER_ID) } returns listOf(TEST_TRAVEL_JOURNAL_ID)
+                every { travelJournalBookmarkRepository.getTravelJournalIds(TEST_USER_ID) } returns listOf(
+                    TEST_TRAVEL_JOURNAL_ID,
+                )
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
                         travelJournalService.getMyTravelJournals(
@@ -610,8 +615,12 @@ class TravelJournalServiceTest : DescribeSpec(
                     )
                 } returns listOf(TEST_TRAVEL_JOURNAL)
                 every { fileService.getPreAuthenticatedObjectUrl(any<String>()) } returns TEST_FILE_AUTHENTICATED_URL
-                every { followRepository.findFollowingIdsByFollowerId(TEST_OTHER_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
-                every { travelJournalBookmarkRepository.getTravelJournalIds(TEST_OTHER_USER_ID) } returns listOf(TEST_TRAVEL_JOURNAL_ID)
+                every { followRepository.findFollowingIdsByFollowerId(TEST_OTHER_USER_ID) } returns listOf(
+                    TEST_OTHER_USER_ID,
+                )
+                every { travelJournalBookmarkRepository.getTravelJournalIds(TEST_OTHER_USER_ID) } returns listOf(
+                    TEST_TRAVEL_JOURNAL_ID,
+                )
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
                         travelJournalService.getFriendTravelJournals(
@@ -640,8 +649,12 @@ class TravelJournalServiceTest : DescribeSpec(
                     )
                 } returns listOf(TEST_TRAVEL_JOURNAL)
                 every { fileService.getPreAuthenticatedObjectUrl(any<String>()) } returns TEST_FILE_AUTHENTICATED_URL
-                every { followRepository.findFollowingIdsByFollowerId(TEST_OTHER_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
-                every { travelJournalBookmarkRepository.getTravelJournalIds(TEST_OTHER_USER_ID) } returns listOf(TEST_TRAVEL_JOURNAL_ID)
+                every { followRepository.findFollowingIdsByFollowerId(TEST_OTHER_USER_ID) } returns listOf(
+                    TEST_OTHER_USER_ID,
+                )
+                every { travelJournalBookmarkRepository.getTravelJournalIds(TEST_OTHER_USER_ID) } returns listOf(
+                    TEST_TRAVEL_JOURNAL_ID,
+                )
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
                         travelJournalService.getRecommendTravelJournals(
@@ -660,7 +673,9 @@ class TravelJournalServiceTest : DescribeSpec(
             context("유효한 데이터가 주어지는 경우") {
                 every { userRepository.getByUserId(TEST_USER_ID) } returns TEST_USER
                 every { followRepository.findFollowingIdsByFollowerId(TEST_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
-                every { travelJournalBookmarkRepository.getTravelJournalIds(TEST_USER_ID) } returns listOf(TEST_TRAVEL_JOURNAL_ID)
+                every { travelJournalBookmarkRepository.getTravelJournalIds(TEST_USER_ID) } returns listOf(
+                    TEST_TRAVEL_JOURNAL_ID,
+                )
                 every {
                     travelJournalRepository.getTaggedTravelJournalSliceBy(
                         TEST_USER,
@@ -857,6 +872,44 @@ class TravelJournalServiceTest : DescribeSpec(
             }
         }
 
+        describe("addTravelJournalContent") {
+            context("유효한 데이터가 주어지는 경우") {
+                val travelJournalContentRequest = createTravelJournalContentRequest(
+                    contentImageNames = listOf(TEST_IMAGE_FILE_WEBP, TEST_OTHER_IMAGE_FILE_WEBP),
+                )
+                every { travelJournalRepository.getByTravelJournalId(TEST_TRAVEL_JOURNAL_ID) } returns createTravelJournal()
+                it("정상적으로 종료한다") {
+                    shouldNotThrowAny {
+                        travelJournalService.addTravelJournalContent(
+                            TEST_TRAVEL_JOURNAL_ID,
+                            travelJournalContentRequest,
+                            createImageNamePairs(),
+                            createPlaceDetailsMap(),
+                        )
+                    }
+                }
+            }
+
+            context("ID에 맞는 여행 일지 콘텐츠가 없는 경우") {
+                val travelJournalContentRequest = createTravelJournalContentRequest(
+                    contentImageNames = listOf(TEST_IMAGE_FILE_WEBP, TEST_OTHER_IMAGE_FILE_WEBP),
+                )
+                every { travelJournalRepository.getByTravelJournalId(TEST_OTHER_TRAVEL_JOURNAL_ID) } throws NoSuchElementException(
+                    "$TEST_OTHER_TRAVEL_JOURNAL_ID : 해당 여행 일지가 존재하지 않습니다.",
+                )
+                it("정상적으로 종료한다") {
+                    shouldThrow<NoSuchElementException> {
+                        travelJournalService.addTravelJournalContent(
+                            TEST_OTHER_TRAVEL_JOURNAL_ID,
+                            travelJournalContentRequest,
+                            createImageNamePairs(),
+                            createPlaceDetailsMap(),
+                        )
+                    }
+                }
+            }
+        }
+
         describe("validateTravelJournalContentUpdateRequest") {
             context("유효한 데이터가 주어지는 경우") {
                 val imageMap = createImageMap(
@@ -982,6 +1035,127 @@ class TravelJournalServiceTest : DescribeSpec(
                             TEST_USER_ID,
                             imageMap,
                             travelJournalContentUpdateRequest,
+                        )
+                    }
+                }
+            }
+        }
+
+        describe("validateTravelJournalContentRequest") {
+            context("유효한 데이터가 주어지는 경우") {
+                val imageMap = createImageMap(
+                    mockFileName = TEST_TRAVEL_JOURNAL_MOCK_FILE_NAME,
+                )
+                val travelJournalContentRequest = createTravelJournalContentRequest(
+                    contentImageNames = listOf(TEST_IMAGE_FILE_WEBP, TEST_OTHER_IMAGE_FILE_WEBP),
+                )
+                every { travelJournalRepository.getByTravelJournalId(TEST_TRAVEL_JOURNAL_ID) } returns createTravelJournal()
+                it("정상적으로 종료한다") {
+                    shouldNotThrowAny {
+                        travelJournalService.validateTravelJournalContentRequest(
+                            TEST_TRAVEL_JOURNAL_ID,
+                            TEST_USER_ID,
+                            travelJournalContentRequest,
+                            imageMap,
+                        )
+                    }
+                }
+            }
+
+            context("작성자와 수정 요청자가 일치하지 않는 경우") {
+                val imageMap = createImageMap(
+                    mockFileName = TEST_TRAVEL_JOURNAL_MOCK_FILE_NAME,
+                )
+                val travelJournalContentRequest = createTravelJournalContentRequest(
+                    contentImageNames = listOf(TEST_IMAGE_FILE_WEBP, TEST_OTHER_IMAGE_FILE_WEBP),
+                )
+                every { travelJournalRepository.getByTravelJournalId(TEST_TRAVEL_JOURNAL_ID) } returns createTravelJournal()
+                it("[ForbiddenException] 반환한다") {
+                    shouldThrow<ForbiddenException> {
+                        travelJournalService.validateTravelJournalContentRequest(
+                            TEST_TRAVEL_JOURNAL_ID,
+                            TEST_OTHER_USER_ID,
+                            travelJournalContentRequest,
+                            imageMap,
+                        )
+                    }
+                }
+            }
+
+            context("여행일지의 총 이미지 개수가 225개를 초과하는 경우") {
+                val travelJournalContentRequest = createTravelJournalContentRequest(
+                    contentImageNames = (0 until 255).map { "updateTestImage$it.webp" }.toList(),
+                )
+                every { travelJournalRepository.getByTravelJournalId(TEST_TRAVEL_JOURNAL_ID) } returns createTravelJournal()
+                it("[IllegalArgumentException] 반환한다") {
+                    shouldThrow<IllegalArgumentException> {
+                        travelJournalService.validateTravelJournalContentRequest(
+                            TEST_TRAVEL_JOURNAL_ID,
+                            TEST_USER_ID,
+                            travelJournalContentRequest,
+                            any<Map<String, MultipartFile>>(),
+                        )
+                    }
+                }
+            }
+
+            context("여행 일지 콘텐츠 이미지의 이름과 실제 이미지의 이름이 다른 경우") {
+                val imageMap = createImageMap(
+                    mockFileName = TEST_TRAVEL_JOURNAL_MOCK_FILE_NAME,
+                )
+                val travelJournalContentRequest = createTravelJournalContentRequest(
+                    contentImageNames = listOf("otherFileName.WEBP", TEST_OTHER_IMAGE_FILE_WEBP),
+                )
+                every { travelJournalRepository.getByTravelJournalId(TEST_TRAVEL_JOURNAL_ID) } returns createTravelJournal()
+                it("[IllegalArgumentException] 반환한다") {
+                    shouldThrow<IllegalArgumentException> {
+                        travelJournalService.validateTravelJournalContentRequest(
+                            TEST_TRAVEL_JOURNAL_ID,
+                            TEST_USER_ID,
+                            travelJournalContentRequest,
+                            imageMap,
+                        )
+                    }
+                }
+            }
+
+            context("여행 일지 콘텐츠의 여행 일자가 여행 기간을 벗어나는 경우") {
+                val imageMap = createImageMap(
+                    mockFileName = TEST_TRAVEL_JOURNAL_MOCK_FILE_NAME,
+                )
+                val travelJournalContentRequest = createTravelJournalContentRequest(
+                    contentImageNames = listOf(TEST_IMAGE_FILE_WEBP, TEST_OTHER_IMAGE_FILE_WEBP),
+                    travelDate = LocalDate.of(2022, 10, 10),
+                )
+                every { travelJournalRepository.getByTravelJournalId(TEST_TRAVEL_JOURNAL_ID) } returns createTravelJournal()
+                it("[IllegalArgumentException] 반환한다") {
+                    shouldThrow<IllegalArgumentException> {
+                        travelJournalService.validateTravelJournalContentRequest(
+                            TEST_TRAVEL_JOURNAL_ID,
+                            TEST_USER_ID,
+                            travelJournalContentRequest,
+                            imageMap,
+                        )
+                    }
+                }
+            }
+
+            context("여행 일지 위도와 경도의 개수가 다른 경우") {
+                val imageMap = createImageMap(
+                    mockFileName = TEST_TRAVEL_JOURNAL_MOCK_FILE_NAME,
+                )
+                val travelJournalContentRequest = createTravelJournalContentRequest(
+                    contentImageNames = listOf(TEST_IMAGE_FILE_WEBP, TEST_OTHER_IMAGE_FILE_WEBP),
+                    latitudes = listOf(123.123),
+                )
+                every { travelJournalRepository.getByTravelJournalId(TEST_TRAVEL_JOURNAL_ID) } returns createTravelJournal()
+                it("[IllegalArgumentException] 반환한다") {
+                    shouldThrow<IllegalArgumentException> {
+                        travelJournalService.validateTravelJournalContentRequest(
+                            TEST_TRAVEL_JOURNAL_ID,
+                            TEST_USER_ID,
+                            travelJournalContentRequest,
+                            imageMap,
                         )
                     }
                 }
@@ -1231,8 +1405,15 @@ class TravelJournalServiceTest : DescribeSpec(
             context("해당 여행일지의 같이 간 친구를 처리할 권한이 없는 경우") {
                 it("정상적으로 종료한다") {
                     every { userRepository.getByUserId(TEST_USER_ID) } returns user
-                    every { travelJournalRepository.findTravelCompanionId(user, TEST_TRAVEL_JOURNAL_ID) } throws ForbiddenException()
-                    every { followRepository.findFollowingIdsByFollowerId(TEST_USER_ID) } returns listOf(TEST_OTHER_USER_ID)
+                    every {
+                        travelJournalRepository.findTravelCompanionId(
+                            user,
+                            TEST_TRAVEL_JOURNAL_ID,
+                        )
+                    } throws ForbiddenException()
+                    every { followRepository.findFollowingIdsByFollowerId(TEST_USER_ID) } returns listOf(
+                        TEST_OTHER_USER_ID,
+                    )
                     shouldThrow<ForbiddenException> {
                         travelJournalService.removeTravelCompanion(TEST_USER_ID, TEST_TRAVEL_JOURNAL_ID)
                     }

--- a/src/test/kotlin/kr/weit/odya/support/TravelJournalFixtures.kt
+++ b/src/test/kotlin/kr/weit/odya/support/TravelJournalFixtures.kt
@@ -63,6 +63,7 @@ const val TEST_TRAVEL_JOURNAL_CONTENT_UPDATE_MOCK_FILE_NAME = "travel-journal-co
 val TEST_TRAVEL_CONTENT_IMAGE_MAP = createImageMap(TEST_TRAVEL_JOURNAL_MOCK_FILE_NAME)
 val TEST_TRAVEL_JOURNAL = createTravelJournal()
 const val TEST_TRAVEL_JOURNAL_REQUEST_NAME = "travel-journal"
+const val TEST_TRAVEL_JOURNAL_CONTENT_REQUEST_NAME = "travel-journal-content"
 const val TEST_TRAVEL_JOURNAL_UPDATE_REQUEST_NAME = "travel-journal-update"
 const val TEST_TRAVEL_JOURNAL_CONTENT_UPDATE_REQUEST_NAME = "travel-journal-content-update"
 const val MAX_TRAVEL_DAYS = 15
@@ -252,6 +253,20 @@ fun createOtherTravelJournalContentImage(contentImage: ContentImage = createCont
 fun createTravelJournalRequestFile(
     name: String = TEST_TRAVEL_JOURNAL_REQUEST_NAME,
     originalFileName: String? = TEST_TRAVEL_JOURNAL_REQUEST_NAME,
+    contentType: String? = TEST_FILE_CONTENT_TYPE,
+    contentStream: InputStream,
+): MockMultipartFile {
+    return MockMultipartFile(
+        name,
+        originalFileName,
+        contentType,
+        contentStream,
+    )
+}
+
+fun createTravelJournalContentRequestFile(
+    name: String = TEST_TRAVEL_JOURNAL_CONTENT_REQUEST_NAME,
+    originalFileName: String? = TEST_TRAVEL_JOURNAL_CONTENT_REQUEST_NAME,
     contentType: String? = TEST_FILE_CONTENT_TYPE,
     contentStream: InputStream,
 ): MockMultipartFile {

--- a/src/test/resources/sql/schema-h2.sql
+++ b/src/test/resources/sql/schema-h2.sql
@@ -502,3 +502,5 @@ CREATE SEQUENCE representative_travel_journal_seq START WITH 1 INCREMENT BY 1;
 CREATE INDEX representative_travel_journal_travel_journal_id_index ON representative_travel_journal (travel_journal_id);
 ALTER TABLE representative_travel_journal
     ADD CONSTRAINT representative_travel_journal_unique UNIQUE (user_id, travel_journal_id);
+
+CREATE INDEX travel_journal_content_travel_travel_date_index ON travel_journal_content (travel_date);


### PR DESCRIPTION
### 개요
- 여행일지에 콘텐츠를 추가할 수 있어야 한다.
### 변경사항
- 이미 등록된 여행일지에 콘텐츠 추가 API
- 여행일지 조회 시, 콘텐츠의 travelDate(여행일자) 순으로 데이터 제공
### 관련 지라 및 위키 링크
- [ODYA-199](https://weit.atlassian.net/browse/ODYA-199)
### 리뷰어에게 하고 싶은 말
- 이제서야 완료하네요.. 🙇‍♂️🙇‍♂️
- 여행일지, 여행일지 콘텐츠 검증 부분 코드에 중복이 많은 것 같아 나중에 공통부분은 묶도록 리팩토링이 필요할 것 같습니다!