### PR TITLE
ODYA-264 알림에 필드 추가

### DIFF
--- a/src/main/kotlin/kr/weit/odya/client/push/FirebaseCloudMessageClient.kt
+++ b/src/main/kotlin/kr/weit/odya/client/push/FirebaseCloudMessageClient.kt
@@ -22,9 +22,7 @@ class FirebaseCloudMessageClient(
                     .build(),
             )
             .apply {
-                for (entry in event.data.entries) {
-                    putData(entry.key, entry.value)
-                }
+                    putAllData(event.data)
             }
             .addAllTokens(event.tokens)
             .build()

--- a/src/main/kotlin/kr/weit/odya/client/push/PushDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/client/push/PushDtos.kt
@@ -1,5 +1,9 @@
 package kr.weit.odya.client.push
 
+import kr.weit.odya.service.dto.UserProfileResponse
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
 data class PushNotificationEvent(
     val title: String,
     val body: String,
@@ -11,7 +15,10 @@ data class PushNotificationEvent(
         body: String,
         tokens: List<String>,
         userName: String,
+        userProfileUrl: String,
+        userProfileColor: UserProfileResponse.ProfileColorResponse?,
         eventType: NotificationEventType,
+        contentImage:String?=null,
         communityId: Long? = null,
         travelJournalId: Long? = null,
         content: String? = null,
@@ -23,13 +30,27 @@ data class PushNotificationEvent(
         data = mutableMapOf(
             "userName" to userName,
             "eventType" to eventType.name,
+            "userProfileUrl" to userProfileUrl,
+            "notifiedAt" to LocalDateTime.now().format(dateTimeFormatter),
         ).apply {
+            userProfileColor?.let {profileColor->
+                put("profileColorHex", profileColor.colorHex)
+                put("profileColorRed", profileColor.red.toString())
+                put("profileColorGreen", profileColor.green.toString())
+                put("profileColorBlue", profileColor.blue.toString())
+            }
             communityId?.toString()?.let { put("communityId", it) }
             travelJournalId?.toString()?.let { put("travelJournalId", it) }
             content?.let { put("content", it) }
             followerId?.toString()?.let { put("followerId", it) }
+            contentImage?.let { put("contentImage", it) }
         },
     )
+
+    companion object{
+        // 멀티쓰레드 환경에서 안전하지 않은 SimpleDateFormat 대신 사용
+       private val dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    }
 }
 
 enum class NotificationEventType {

--- a/src/main/kotlin/kr/weit/odya/service/CommunityCommentService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/CommunityCommentService.kt
@@ -12,12 +12,14 @@ import kr.weit.odya.domain.communitycomment.getCommunityCommentBy
 import kr.weit.odya.domain.communitycomment.getSliceCommunityCommentBy
 import kr.weit.odya.domain.follow.FollowRepository
 import kr.weit.odya.domain.follow.getFollowingIds
+import kr.weit.odya.domain.profilecolor.NONE_PROFILE_COLOR_HEX
 import kr.weit.odya.domain.user.User
 import kr.weit.odya.domain.user.UserRepository
 import kr.weit.odya.domain.user.getByUserId
 import kr.weit.odya.service.dto.CommunityCommentRequest
 import kr.weit.odya.service.dto.CommunityCommentResponse
 import kr.weit.odya.service.dto.SliceResponse
+import kr.weit.odya.service.dto.UserProfileResponse
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -98,6 +100,13 @@ class CommunityCommentService(
                 body = "${commentWriter.nickname}님이 댓글을 남겼습니다 : ${communityComment.content}",
                 tokens = listOf(token),
                 userName = commentWriter.nickname,
+                userProfileUrl = fileService.getPreAuthenticatedObjectUrl(commentWriter.profile.profileName),
+                userProfileColor = if (commentWriter.profile.profileColor.colorHex != NONE_PROFILE_COLOR_HEX) {
+                    UserProfileResponse.ProfileColorResponse(commentWriter.profile.profileColor)
+                } else {
+                    null
+                },
+                contentImage = fileService.getPreAuthenticatedObjectUrl(community.communityContentImages[0].contentImage.name) ,
                 eventType = NotificationEventType.COMMUNITY_COMMENT,
                 communityId = community.id,
                 content = communityComment.content,

--- a/src/main/kotlin/kr/weit/odya/service/CommunityLikeService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/CommunityLikeService.kt
@@ -8,9 +8,11 @@ import kr.weit.odya.domain.community.getByCommunityId
 import kr.weit.odya.domain.communitylike.CommunityLike
 import kr.weit.odya.domain.communitylike.CommunityLikeId
 import kr.weit.odya.domain.communitylike.CommunityLikeRepository
+import kr.weit.odya.domain.profilecolor.NONE_PROFILE_COLOR_HEX
 import kr.weit.odya.domain.user.User
 import kr.weit.odya.domain.user.UserRepository
 import kr.weit.odya.domain.user.getByUserId
+import kr.weit.odya.service.dto.UserProfileResponse
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -21,6 +23,7 @@ class CommunityLikeService(
     private val communityRepository: CommunityRepository,
     private val userRepository: UserRepository,
     private val eventPublisher: ApplicationEventPublisher,
+    private val fileService: FileService,
 ) {
     @Transactional
     fun increaseCommunityLikeCount(communityId: Long, userId: Long) {
@@ -55,6 +58,13 @@ class CommunityLikeService(
                 body = "${likeUser.nickname}님께 오댜를 받았습니다",
                 tokens = listOf(token),
                 userName = likeUser.nickname,
+                userProfileUrl = fileService.getPreAuthenticatedObjectUrl(likeUser.profile.profileName),
+                userProfileColor = if (likeUser.profile.profileColor.colorHex != NONE_PROFILE_COLOR_HEX) {
+                    UserProfileResponse.ProfileColorResponse(likeUser.profile.profileColor)
+                } else {
+                    null
+                },
+                contentImage = fileService.getPreAuthenticatedObjectUrl(community.communityContentImages[0].contentImage.name),
                 eventType = NotificationEventType.COMMUNITY_LIKE,
                 communityId = community.id,
             ),

--- a/src/main/kotlin/kr/weit/odya/service/CommunityService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/CommunityService.kt
@@ -27,6 +27,7 @@ import kr.weit.odya.domain.contentimage.ContentImage
 import kr.weit.odya.domain.follow.FollowRepository
 import kr.weit.odya.domain.follow.getFollowerFcmTokens
 import kr.weit.odya.domain.follow.getFollowingIds
+import kr.weit.odya.domain.profilecolor.NONE_PROFILE_COLOR_HEX
 import kr.weit.odya.domain.report.ReportCommunityRepository
 import kr.weit.odya.domain.report.deleteAllByUserId
 import kr.weit.odya.domain.topic.TopicRepository
@@ -47,6 +48,7 @@ import kr.weit.odya.service.dto.CommunityUpdateRequest
 import kr.weit.odya.service.dto.CommunityWithCommentsResponse
 import kr.weit.odya.service.dto.SliceResponse
 import kr.weit.odya.service.dto.TravelJournalSimpleResponse
+import kr.weit.odya.service.dto.UserProfileResponse
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -391,6 +393,13 @@ class CommunityService(
                 body = "${user.nickname}님이 피드를 작성했어요!",
                 tokens = fcmTokens,
                 userName = user.nickname,
+                userProfileUrl = fileService.getPreAuthenticatedObjectUrl(user.profile.profileName),
+                userProfileColor = if (user.profile.profileColor.colorHex != NONE_PROFILE_COLOR_HEX) {
+                    UserProfileResponse.ProfileColorResponse(user.profile.profileColor)
+                } else {
+                    null
+                },
+                contentImage = fileService.getPreAuthenticatedObjectUrl(community.communityContentImages[0].contentImage.name),
                 eventType = NotificationEventType.FOLLOWING_COMMUNITY,
                 communityId = community.id,
             ),

--- a/src/main/kotlin/kr/weit/odya/service/FollowService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/FollowService.kt
@@ -12,6 +12,7 @@ import kr.weit.odya.domain.follow.getFollowingIds
 import kr.weit.odya.domain.follow.getFollowingListBySearchCond
 import kr.weit.odya.domain.follow.getMayKnowFollowings
 import kr.weit.odya.domain.follow.getVisitedFollowingIds
+import kr.weit.odya.domain.profilecolor.NONE_PROFILE_COLOR_HEX
 import kr.weit.odya.domain.user.User
 import kr.weit.odya.domain.user.UserRepository
 import kr.weit.odya.domain.user.UsersDocumentRepository
@@ -22,6 +23,7 @@ import kr.weit.odya.service.dto.FollowCountsResponse
 import kr.weit.odya.service.dto.FollowRequest
 import kr.weit.odya.service.dto.FollowUserResponse
 import kr.weit.odya.service.dto.SliceResponse
+import kr.weit.odya.service.dto.UserProfileResponse
 import kr.weit.odya.service.dto.VisitedFollowingResponse
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.Pageable
@@ -58,6 +60,12 @@ class FollowService(
                 body = "${follower.nickname}님이 회원님을 팔로우했습니다",
                 tokens = listOf(token),
                 userName = follower.nickname,
+                userProfileUrl = fileService.getPreAuthenticatedObjectUrl(follower.profile.profileName),
+                userProfileColor = if (follower.profile.profileColor.colorHex != NONE_PROFILE_COLOR_HEX) {
+                    UserProfileResponse.ProfileColorResponse(follower.profile.profileColor)
+                } else {
+                    null
+                },
                 eventType = NotificationEventType.FOLLOWER_ADD,
                 followerId = follower.id,
             ),

--- a/src/main/kotlin/kr/weit/odya/service/UserService.kt
+++ b/src/main/kotlin/kr/weit/odya/service/UserService.kt
@@ -138,10 +138,10 @@ class UserService(
 
     @Transactional
     fun updateFcmToken(userId: Long, fcmTokenRequest: FCMTokenRequest) {
-        val user = userRepository.getByUserId(userId)
-        user.changeFcmToken(fcmTokenRequest.fcmToken)
         // FCM토큰이 충돌나는 경우 기존 유저의 토큰을 무효화 한다
         userRepository.findByFcmToken(fcmTokenRequest.fcmToken)?.changeFcmToken(null)
+        val user = userRepository.getByUserId(userId)
+        user.changeFcmToken(fcmTokenRequest.fcmToken)
     }
 
     @Transactional

--- a/src/test/kotlin/kr/weit/odya/service/CommunityLikeServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/CommunityLikeServiceTest.kt
@@ -27,8 +27,9 @@ class CommunityLikeServiceTest : DescribeSpec(
         val communityRepository = mockk<CommunityRepository>()
         val userRepository = mockk<UserRepository>()
         val eventPublisher = mockk<ApplicationEventPublisher>()
+        val fileService = mockk<FileService>()
         val communityLikeService =
-            CommunityLikeService(communityLikeRepository, communityRepository, userRepository, eventPublisher)
+            CommunityLikeService(communityLikeRepository, communityRepository, userRepository, eventPublisher,fileService)
 
         describe("increaseCommunityLikeCount") {
             context("유효한 요청이 주어지는 경우") {

--- a/src/test/kotlin/kr/weit/odya/service/CommunityServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/CommunityServiceTest.kt
@@ -120,6 +120,7 @@ class CommunityServiceTest : DescribeSpec(
                 every { followRepository.findFollowerFcmTokenByFollowingId(TEST_USER_ID) } returns createFollowerFcmTokenList()
                 every { applicationEventPublisher.publishEvent(any<PushNotificationEvent>()) } just runs
                 every { googleMapsClient.findPlaceDetailsByPlaceId(any()) } returns createPlaceDetails()
+                every {fileService.getPreAuthenticatedObjectUrl(any())} returns TEST_FILE_AUTHENTICATED_URL
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
                         communityService.createCommunity(
@@ -163,6 +164,7 @@ class CommunityServiceTest : DescribeSpec(
                 every { communityRepository.save(any<Community>()) } returns createCommunity()
                 every { followRepository.findFollowerFcmTokenByFollowingId(TEST_USER_ID) } returns createFollowerFcmTokenList()
                 every { applicationEventPublisher.publishEvent(any<PushNotificationEvent>()) } just runs
+                every {fileService.getPreAuthenticatedObjectUrl(any())} returns TEST_FILE_AUTHENTICATED_URL
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
                         communityService.createCommunity(

--- a/src/test/kotlin/kr/weit/odya/service/TravelJournalServiceTest.kt
+++ b/src/test/kotlin/kr/weit/odya/service/TravelJournalServiceTest.kt
@@ -125,6 +125,7 @@ class TravelJournalServiceTest : DescribeSpec(
                 every { travelJournalRepository.save(any<TravelJournal>()) } returns TEST_TRAVEL_JOURNAL
                 every { followRepository.findFollowerFcmTokenByFollowingId(TEST_USER_ID) } returns createFollowerFcmTokenList()
                 every { applicationEventPublisher.publishEvent(any<PushNotificationEvent>()) } just runs
+                every {fileService.getPreAuthenticatedObjectUrl(any())} returns TEST_FILE_AUTHENTICATED_URL
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
                         travelJournalService.createTravelJournal(
@@ -150,6 +151,7 @@ class TravelJournalServiceTest : DescribeSpec(
                 every { travelJournalRepository.save(any<TravelJournal>()) } returns TEST_TRAVEL_JOURNAL
                 every { followRepository.findFollowerFcmTokenByFollowingId(TEST_USER_ID) } returns createFollowerFcmTokenList()
                 every { applicationEventPublisher.publishEvent(any<PushNotificationEvent>()) } just runs
+                every {fileService.getPreAuthenticatedObjectUrl(any())} returns TEST_FILE_AUTHENTICATED_URL
                 it("정상적으로 종료한다") {
                     shouldNotThrowAny {
                         travelJournalService.createTravelJournal(


### PR DESCRIPTION
### 개요
- 유저 프로필 정보와 알림 시간, 컨텐츠 이미지 정보가 알림을 보낼때 같이 보내야 한다
- FCM 토큰 업데이트 로직 버그 발견

### 변경사항
- 필요한 필드 추가
- FCM 토큰 업데이트 로직 서순 수정

### 관련 지라 및 위키 링크
- [ODYA-264](https://weit.atlassian.net/browse/ODYA-264)

### 리뷰어에게 하고 싶은 말
- 지혜님이 제보해주셔서 작업했고 작업중에 버그를 발견해서 같이 수정했습니다 ㅋㅋㅋ..
