### PR TITLE
ODYA-286 알림 필드 수정

### DIFF
--- a/src/main/kotlin/kr/weit/odya/client/push/FirebaseCloudMessageClient.kt
+++ b/src/main/kotlin/kr/weit/odya/client/push/FirebaseCloudMessageClient.kt
@@ -2,7 +2,6 @@ package kr.weit.odya.client.push
 
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.MulticastMessage
-import com.google.firebase.messaging.Notification
 import org.springframework.stereotype.Component
 
 @Component
@@ -15,12 +14,6 @@ class FirebaseCloudMessageClient(
         }
 
         val message = MulticastMessage.builder()
-            .setNotification(
-                Notification.builder()
-                    .setTitle(event.title)
-                    .setBody(event.body)
-                    .build(),
-            )
             .apply {
                 putAllData(event.data)
             }

--- a/src/main/kotlin/kr/weit/odya/client/push/PushDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/client/push/PushDtos.kt
@@ -5,8 +5,6 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 data class PushNotificationEvent(
-    val title: String,
-    val body: String,
     val tokens: List<String>,
     val data: Map<String, String>,
 ) {
@@ -24,10 +22,10 @@ data class PushNotificationEvent(
         content: String? = null,
         followerId: Long? = null,
     ) : this(
-        title = title,
-        body = body,
         tokens = tokens,
         data = mutableMapOf(
+            "title" to title,
+            "body" to body,
             "userName" to userName,
             "eventType" to eventType.name,
             "userProfileUrl" to userProfileUrl,


### PR DESCRIPTION
### 개요
- FCM알림을 보내는 방식은 2가지가 있는데
1. 서버가 알림 요청을 만들어서 클라이언트에게 알림을 띄우도록 강제하는 방식
2. 서버는 알림에 필요한 정보만 제공하고 클라가 조합하고 알림을 띄울지 말지 선택하는 방식
- 현재 코드에서는 1번으로 되어있어서 클라가 알림을 조절할수 없는 이슈가 있었다

### 변경사항
- 서버가 알림에 필요한 정보만 제공하고 알림요청을 만들어 내지 않도록 수정

### 관련 지라 및 위키 링크
- [ODYA-286](https://weit.atlassian.net/browse/ODYA-286)

### 리뷰어에게 하고 싶은 말
- 예전에 알림부분 개발할때 2가지 방식을 구현하는게 헷갈려서 2번방식으로 만드려고 했지만 1번으로 만들었었네요 ㅋㅋㅋ;;
- 지혜님이 제보해주셔서 빠르게 작업했습니다~!
