### PR TITLE
ODYA-289 IOS에서 알림이 안오는 이슈 해결

### DIFF
--- a/src/main/kotlin/kr/weit/odya/client/push/FirebaseCloudMessageClient.kt
+++ b/src/main/kotlin/kr/weit/odya/client/push/FirebaseCloudMessageClient.kt
@@ -1,5 +1,8 @@
 package kr.weit.odya.client.push
 
+import com.google.firebase.messaging.ApnsConfig
+import com.google.firebase.messaging.Aps
+import com.google.firebase.messaging.ApsAlert
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.MulticastMessage
 import org.springframework.stereotype.Component
@@ -12,11 +15,25 @@ class FirebaseCloudMessageClient(
         if (event.tokens.isEmpty()) {
             return
         }
+        // data만 보내면 iOS는 받지 못해서 iOS를 위한 설정
+        val apnsConfig =
+            ApnsConfig.builder().setAps(
+                Aps.builder()
+                    .setContentAvailable(true)
+                    .setAlert(
+                        ApsAlert
+                            .builder()
+                            .setTitle(event.title)
+                            .setBody(event.body)
+                            .build(),
+                    ).build(),
+            ).build()
 
         val message = MulticastMessage.builder()
             .apply {
                 putAllData(event.data)
             }
+            .setApnsConfig(apnsConfig)
             .addAllTokens(event.tokens)
             .build()
 

--- a/src/main/kotlin/kr/weit/odya/client/push/PushDtos.kt
+++ b/src/main/kotlin/kr/weit/odya/client/push/PushDtos.kt
@@ -5,6 +5,8 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 data class PushNotificationEvent(
+    val title: String,
+    val body: String,
     val tokens: List<String>,
     val data: Map<String, String>,
 ) {
@@ -22,6 +24,8 @@ data class PushNotificationEvent(
         content: String? = null,
         followerId: Long? = null,
     ) : this(
+        title = title,
+        body = body,
         tokens = tokens,
         data = mutableMapOf(
             "title" to title,


### PR DESCRIPTION
### 개요
- iOS에서는 푸시 알림을 못받고 있었다

### 변경사항
- iOS에서는 알림이 뜨도록 강제 하는 코드 추가

### 관련 지라 및 위키 링크
- [ODYA-289](https://weit.atlassian.net/browse/ODYA-289)

### 리뷰어에게 하고 싶은 말
- 요건 정아님이 제보해주신 내용이라 빠르게 작업했습니다
- data만 보내면 iOS에서는 알림이 안온다고 하더라구요..!
- 그리고 알림을 서버가 강제해도 클라에서 안뜨게 막을 방법이 있다고 하셔서 그방향으로 작업했습니다~!
